### PR TITLE
Feature/update mdpp

### DIFF
--- a/00-setup-introduction.md
+++ b/00-setup-introduction.md
@@ -15,11 +15,11 @@
 This exercise introduces the sentences application which you will be using during the course.
 It also introduces you to the Kiali management console for the Istio service mesh.
 
-In the beginning of the exercise you will deploy the sentences application 
-and generate traffic between the services. But there will be no Envoy sidecars 
+In the beginning of the exercise you will deploy the sentences application
+and generate traffic between the services. But there will be no Envoy sidecars
 injected and Kiali will not be able to observe the traffic.
 
-Afterwards you will use a couple of different methods to enable sidecars. This 
+Afterwards you will use a couple of different methods to enable sidecars. This
 will allow Kiali to observe the traffic.
 
 <details>
@@ -43,12 +43,12 @@ The source code for the application can be seen in the  [sentences-app/](sentenc
 
 ### Kiali
 
-Kiali provides dashboards and observability by showing you the structure and 
-health of your service mesh. It provides detailed metrics, Grafana access and 
+Kiali provides dashboards and observability by showing you the structure and
+health of your service mesh. It provides detailed metrics, Grafana access and
 integrates with Jaeger for distributed tracing.
 
-One of it's most powerful features are it's graphs. They provide a powerful way 
-to visualize the topology of your service mesh. 
+One of it's most powerful features are it's graphs. They provide a powerful way
+to visualize the topology of your service mesh.
 
 It provides four main graph renderings of the mesh telemetry.
 
@@ -68,11 +68,11 @@ We are using Kiali to visualize the work done in this Istio course.
 
 ## Exercise: Get Familiar with Istio and Kiali.
 
-In this exercise, we are first deploying our application with vanilla 
-Kubernetes. We then visit the Kiali website to see that without a 
+In this exercise, we are first deploying our application with vanilla
+Kubernetes. We then visit the Kiali website to see that without a
 sidecar our service will not be included in istio.
 
-Then you will be using a few different techniques to enable Istio sidecars 
+Then you will be using a few different techniques to enable Istio sidecars
 and see the traffic flowing in Kiali.
 
 ### Overview
@@ -102,15 +102,15 @@ Expand the **Tasks** section below to do the exercise.
 
 ___
 
-You will need to know your namespace for later exercises. It is provided for 
-you in the environment variable `STUDENT_NS`. Check it with the following 
+You will need to know your namespace for later exercises. It is provided for
+you in the environment variable `STUDENT_NS`. Check it with the following
 command.
 
 ```console
 echo $STUDENT_NS
 ```
 
-Execute the following command and make sure it matches the value of the 
+Execute the following command and make sure it matches the value of the
 environment variable `STUDENT_NS`.
 
 ```console
@@ -179,16 +179,16 @@ Traffic is now flowing between the services. But that **doesn't** mean it is par
 ___
 
 
-Browse to **Applications** on the left hand menu. Click **Namespace** drop-down at the top left and 
+Browse to **Applications** on the left hand menu. Click **Namespace** drop-down at the top left and
 enter **your** namespace.
 
 Finally, select your `sentences` application from the center-part of the UI.
 
-You will see the application, workloads and services are discovered by Kiali. 
+You will see the application, workloads and services are discovered by Kiali.
 But not much else.
 
 The red icons beside the workloads mean we have no istio sidecars deployed.
-Browse the different tabs to see that there is no traffic nor metrics being captured. 
+Browse the different tabs to see that there is no traffic nor metrics being captured.
 As there are no sidecars the traffic is **not** part of the istio service mesh.
 
 ![Sentences with no sidecars](images/kiali-no-sidecars.png)
@@ -273,11 +273,11 @@ Browse to **Applications** on the left hand menu and select `sentences`.
 
 > Remember to filter by **your** namespace.
 
-Now you can see there are sidecars and the traffic is part of the mesh. 
+Now you can see there are sidecars and the traffic is part of the mesh.
 
 - Browse the different tabs to see the traffic and metrics being captured.
 
-> :bulb: It may take a minute before Kiali starts showing the traffic and 
+> :bulb: It may take a minute before Kiali starts showing the traffic and
 > metrics. You can change the refresh rate in the top right hand corner.
 
 ![Sentences with sidecars](images/kiali-with-sidecars.png)
@@ -288,7 +288,7 @@ Now you can see there are sidecars and the traffic is part of the mesh.
 ___
 
 
-Edit the file `00-setup-introduction/age.yaml` and add the annotation 
+Edit the file `00-setup-introduction/age.yaml` and add the annotation
 `sidecar.istio.io/inject: 'false'`.
 
 ```yaml
@@ -338,7 +338,7 @@ Use kubectl to see the number of pods running.
 kubectl get pods
 ```
 
-You should, eventually, see that the `age` service has only **one** pod. 
+You should, eventually, see that the `age` service has only **one** pod.
 E.g. it no longer has a sidecar and is **not** part of the service mesh.
 
 ```
@@ -351,9 +351,9 @@ sentences-v1-7cfbb658b6-rthxn   2/2     Running   0          8m41s
 If you re-inspect the application graph in Kiali, you will also
 notice, that the `age` service is no longer being shown.
 
-> Automatic sidecar injection provides a **pervasive** and homogenous approach 
-> to ensuring the features istio provides. For example telemetry like metrics 
-> and traces for observability. If you do not want a sidecar for a service, use 
+> Automatic sidecar injection provides a **pervasive** and homogenous approach
+> to ensuring the features istio provides. For example telemetry like metrics
+> and traces for observability. If you do not want a sidecar for a service, use
 > an **opt out** approach.
 
 #### Task: Inject sidecar for the `age` service
@@ -374,7 +374,7 @@ Use kubectl to see the number of pods running.
 kubectl get pods
 ```
 
-You should now see that the `age` service again has **two** pods. E.g. it has 
+You should now see that the `age` service again has **two** pods. E.g. it has
 a sidecar and is **again** part of the service mesh.
 
 ```
@@ -387,8 +387,8 @@ sentences-v1-7cfbb658b6-rthxn   2/2     Running   0          16m
 If you inspect the application graph in Kiali, you will see that the
 `age` service again is being shown.
 
-You didn't modify the static yaml with the above command. You simply took the 
-output of the cat command, piped it into grep which stripped out the annotation 
+You didn't modify the static yaml with the above command. You simply took the
+output of the cat command, piped it into grep which stripped out the annotation
 and applied the **output** with kubectl.
 
 #### Task: Investigate the different graphs
@@ -396,12 +396,12 @@ and applied the **output** with kubectl.
 ___
 
 
-Browse to the **graphs** and investigate the service, workload, app 
+Browse to the **graphs** and investigate the service, workload, app
 and versioned app graphs from the drop down at the top.
 
-> :bulb: Use the display options to modify what is shown in the 
+> :bulb: Use the display options to modify what is shown in the
 > different graphs. Showing request distribution is something
-> we will be using often. Also ensure you are running the 
+> we will be using often. Also ensure you are running the
 > `loop-query.sh` script to generate traffic.
 
 > :bulb: Use the `Legend` button to explain the different objects being shown.
@@ -412,34 +412,33 @@ and versioned app graphs from the drop down at the top.
 
 # Summary
 
-In this exercise you injected sidecars with automatic sidecar injection, 
-disabled sidecars with an annotation and manually injected a sidecar from 
-the command line.  Manually injecting sidecars or using annotations is not 
+In this exercise you injected sidecars with automatic sidecar injection,
+disabled sidecars with an annotation and manually injected a sidecar from
+the command line.  Manually injecting sidecars or using annotations is not
 a cohesive approach.
 
-You were also introduced to the sentences application and Kiali. There is not 
-enough time in the course to go into much more details around Kiali. But it 
-has more features like the Istio Wizards feature which lets you create and 
-delete istio configuration on the fly. It can do validation on the most common 
-Istio objects and more. 
+You were also introduced to the sentences application and Kiali. There is not
+enough time in the course to go into much more details around Kiali. But it
+has more features like the Istio Wizards feature which lets you create and
+delete istio configuration on the fly. It can do validation on the most common
+Istio objects and more.
 
-    
-See the [documentation](https://kiali.io/docs/features/) 
+See the [documentation](https://kiali.io/docs/features/)
 for a more complete overview.
 
 Main takeaways are:
 
 * Annotations can be used to control sidecar injection.
 
-* Automatic sidecar injections is recommended. Automatic sidecar injection 
-ensures a more **pervasive** and homogenous approach for traffic management 
-and observability. It is less intrusive as it happens at the pod level and 
+* Automatic sidecar injections is recommended. Automatic sidecar injection
+ensures a more **pervasive** and homogenous approach for traffic management
+and observability. It is less intrusive as it happens at the pod level and
 you won't see any changes to the yaml itself.
 
-You can find more information about the different methods 
+You can find more information about the different methods
 [here](https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/).
 
-And you can find more details about sidecar configuration 
+And you can find more details about sidecar configuration
 [here](https://istio.io/latest/docs/concepts/traffic-management/#sidecars).
 
 # Cleanup

--- a/01-basic-traffic-routing.md
+++ b/01-basic-traffic-routing.md
@@ -11,31 +11,31 @@
 
 ## Introduction
 
-This exercise introduce you to the basics of traffic routing with Istio. 
-We are going to deploy all the services for our sentences application 
-and a new version `v2` of the **name** service. This will demonstrate normal 
-kubernetes load balancing between services. 
+This exercise introduce you to the basics of traffic routing with Istio.
+We are going to deploy all the services for our sentences application
+and a new version `v2` of the **name** service. This will demonstrate normal
+kubernetes load balancing between services.
 
 Then we are going to use two Istio custom resource definitions([CRD's](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)) which are
-the building blocks of Istio's traffic routing functionality to route traffic to 
+the building blocks of Istio's traffic routing functionality to route traffic to
 the desired workloads.
 
 These are the [VirtualService](https://istio.io/latest/docs/reference/config/networking/virtual-service/) and the [DestinationRule](https://istio.io/latest/docs/reference/config/networking/destination-rule/) CRD's.
 
-> :bulb: If you have not completed exercise 
-> [00-setup-introduction](00-setup-introduction.md) you **need** to label 
+> :bulb: If you have not completed exercise
+> [00-setup-introduction](00-setup-introduction.md) you **need** to label
 > your namespace with `istio-injection=enabled`.
 
 ### VirtualService
 
-You use virtual services to route traffic to kubernetes services. 
+You use virtual services to route traffic to kubernetes services.
 
 A VirtualService is used in addition to the normal Kubernetes service object.
-A VirtualService defines a set of traffic routing rules to apply when a host 
-is addressed. 
+A VirtualService defines a set of traffic routing rules to apply when a host
+is addressed.
 
-Each routing rule defines matching criteria for traffic of a 
-specific protocol. If the traffic is matched, then it is sent to a named 
+Each routing rule defines matching criteria for traffic of a
+specific protocol. If the traffic is matched, then it is sent to a named
 destination **service** or subset/version of it.
 
 > **Expand the example below for more details.**
@@ -60,45 +60,45 @@ spec:
         subset: v1          # but only this subset of the Deployment
 ```
 
-- The **http** block is an [HTTPRoute](https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPRoute) 
-containing the routing rules for HTTP/1.1, HTTP/2 and gRPC traffic. 
+- The **http** block is an [HTTPRoute](https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPRoute)
+containing the routing rules for HTTP/1.1, HTTP/2 and gRPC traffic.
 
-> You can also use [TCPRoute](https://istio.io/latest/docs/reference/config/networking/virtual-service/#TCPRoute) 
-> and [TLSRoute](https://istio.io/latest/docs/reference/config/networking/virtual-service/#TLSRoute) 
+> You can also use [TCPRoute](https://istio.io/latest/docs/reference/config/networking/virtual-service/#TCPRoute)
+> and [TLSRoute](https://istio.io/latest/docs/reference/config/networking/virtual-service/#TLSRoute)
 > blocks for configuring routing.
 
-- The **hosts** field is the user addressable destination that the routing rules 
+- The **hosts** field is the user addressable destination that the routing rules
 apply to. It is the address used by a client when attempting to connect to a service.
-This is **virtual** and doesn't actually have to exist. For example 
-You could use it for consolidating routes to all services for an application. 
+This is **virtual** and doesn't actually have to exist. For example
+You could use it for consolidating routes to all services for an application.
 
-- The **destination** field specifies the **actual** destination of the routing 
-rule and **must** exist. In kubernetes this is a **service** and generally 
+- The **destination** field specifies the **actual** destination of the routing
+rule and **must** exist. In kubernetes this is a **service** and generally
 takes a form like `reviews`, `ratings`, etc.
-    
+
 - The **weight** field can be used to specify the distribution of traffic,
     Within a single route.
 
-- The `mesh` field in the gateways block is a reserved keyword used to imply 
+- The `mesh` field in the gateways block is a reserved keyword used to imply
 **all** sidecars in the mesh.
 
-- The subset block is the name of a subset within the service and **must** be 
+- The subset block is the name of a subset within the service and **must** be
 defined in a **DestinationRule**.
 
 </details>
 
 ### DestinationRule
 
-Destination rules configure **what** happens to traffic for a destination 
+Destination rules configure **what** happens to traffic for a destination
 defined in a virtual service.
 
-You can think of virtual services as **how** you route your traffic to a given 
-destination, and then you use destination rules to configure **what** happens 
+You can think of virtual services as **how** you route your traffic to a given
+destination, and then you use destination rules to configure **what** happens
 to traffic for that destination.
 
 One of the most common uses of `DestinationRule` is to specify named service **subsets**.
 
-For example, grouping all of a service instances **versions**. You can then 
+For example, grouping all of a service instances **versions**. You can then
 use these **subsets** in a virtual service to control traffic to different versions.
 
 > **Expand the example below for more details.**
@@ -125,20 +125,20 @@ spec:
       version: v3
 ```
 
-> Destination rules are applied by Istio **after** virtual service routing 
+> Destination rules are applied by Istio **after** virtual service routing
 > rules are **evaluated**, so they apply to the traffic’s “real” destination.
 
-> :bulb: If you have not completed exercise 
-> [00-setup-introduction](00-setup-introduction.md) you **need** to label 
+> :bulb: If you have not completed exercise
+> [00-setup-introduction](00-setup-introduction.md) you **need** to label
 > your namespace with `istio-injection=enabled`.
 
 </details>
 
 ## Exercise: Routing To Specific Version
 
-We will look a bit into how a VirtualService and a DestinationRule can control 
-the flow of traffic in your namespace. We spin up two versions of the name 
-service in the namespace, and use the VirtualService and DestinationRule kinds 
+We will look a bit into how a VirtualService and a DestinationRule can control
+the flow of traffic in your namespace. We spin up two versions of the name
+service in the namespace, and use the VirtualService and DestinationRule kinds
 to control the traffic.
 
 ### Overview
@@ -153,10 +153,10 @@ A general overview of what you will be doing in the **Step By Step** section.
 
 - Use Kiali to observe the traffic flow
 
-- Create a VirtualService to route **all** traffic to the native k8's service 
+- Create a VirtualService to route **all** traffic to the native k8's service
 for name
 
-- Create a DestinationRule to send traffic to a specific version(workload) of 
+- Create a DestinationRule to send traffic to a specific version(workload) of
 the name service
 
 ### Step By Step
@@ -191,17 +191,17 @@ ___
 ___
 
 
-Go to Graph menu item and select the **Versioned app graph** from the drop 
+Go to Graph menu item and select the **Versioned app graph** from the drop
 down menu.
 
 ![50/50 split of traffic](images/kiali-blue-green-anno.png)
 
 What you are seeing here is kubernetes load balancing between PODS.
-Kubernetes, or more specifically the `kube-proxy`, will load balance in 
-either a *round robin* or *random* pattern depending on whether it is 
+Kubernetes, or more specifically the `kube-proxy`, will load balance in
+either a *round robin* or *random* pattern depending on whether it is
 running in *user space* proxy mode or *IP tables* proxy mode.
 
-You rarely want traffic routed to two version in an uncontrolled 
+You rarely want traffic routed to two version in an uncontrolled
 fashion.
 
 So why is this happening?
@@ -214,7 +214,7 @@ So why is this happening?
 ___
 
 
-Create a destination rule called `name-dr.yaml` in 
+Create a destination rule called `name-dr.yaml` in
 `01-basic-traffic-routing/start/` and apply it.
 
 ```yaml
@@ -234,16 +234,16 @@ spec:
     labels:
       version: v2
 ```
-The above destination rule says, when combined with a virtual service, **what** 
+The above destination rule says, when combined with a virtual service, **what**
 I want to do is send traffic to a workload **labeled** with either `v1` or `v2`.
 
 ```console
 kubectl apply -f 01-basic-traffic-routing/start/name-dr.yaml
 ```
-Applying the destination rule has no effect at this point because there is no 
+Applying the destination rule has no effect at this point because there is no
 virtual service including the destination rule.
 
-> :bulb: To avoid 503 errors **always** apply destination rules and changes to 
+> :bulb: To avoid 503 errors **always** apply destination rules and changes to
 > destination rules **prior** to changing virtual services.
 
 #### Task: Create a `VirtualService` to route ALL traffic to version 1 of the name service
@@ -251,7 +251,7 @@ virtual service including the destination rule.
 ___
 
 
-Create a virtual service called `name-vs.yaml` in 
+Create a virtual service called `name-vs.yaml` in
 `01-basic-traffic-routing/start/` and apply it.
 
 ```yaml
@@ -273,10 +273,10 @@ spec:
         subset: name-v1
 ```
 
-> The `host` field in the above yaml is the kubernetes short name for the service. 
-> Istio will translate the short name based one the **namespace** of the rule. 
-> E.g. if the virtual service is in namespace `default` the short name name will 
-> be interpreted as `name.default.svc.cluster.local`. What will happen if the 
+> The `host` field in the above yaml is the kubernetes short name for the service.
+> Istio will translate the short name based one the **namespace** of the rule.
+> E.g. if the virtual service is in namespace `default` the short name name will
+> be interpreted as `name.default.svc.cluster.local`. What will happen if the
 > **name** service is in the namespace `student1`?
 
 ```console
@@ -287,25 +287,25 @@ Immediately after applying this, you will see the output from the
 `loop-query.sh` change and strings with '(v2)' in them are no longer
 received.
 
-Go to **Graph** menu item in Kiali and select the **Versioned app graph** 
-from the drop down menu and observe the traffic flow. It may take a minute 
-before fully complete but you should see the traffic being routed to the 
+Go to **Graph** menu item in Kiali and select the **Versioned app graph**
+from the drop down menu and observe the traffic flow. It may take a minute
+before fully complete but you should see the traffic being routed to the
 `name-v1` **service**.
 
-> :bulb: Make sure to select `Idle Edges`, `Service Nodes` and 
+> :bulb: Make sure to select `Idle Edges`, `Service Nodes` and
 > `Virtual Services` in the Display drop down.
 
 ![Basic virtual service route](images/basic-route-vs.png)
 
-You can see in Kiali that the virtual service combined with the destination 
-rule subsets routes traffic to the name workload labeled `v1` even though the 
+You can see in Kiali that the virtual service combined with the destination
+rule subsets routes traffic to the name workload labeled `v1` even though the
 name service has no versions defined in the selector.
 
 #### Task: Add a route to version 2 of the name service as the **first** route
 
 ___
 
-Add a destination to the new service in the `name-vs.yaml` you 
+Add a destination to the new service in the `name-vs.yaml` you
 created before. But place it **before** the `name-v1` service and apply it.
 
 ```yaml
@@ -344,24 +344,24 @@ received.
 ___
 
 
-Go to **Graph** menu item in Kiali and select the **Versioned app graph** 
-from the drop down menu and observe the traffic flow. You will see that 
+Go to **Graph** menu item in Kiali and select the **Versioned app graph**
+from the drop down menu and observe the traffic flow. You will see that
 traffic is now being routed to the version 2 service.
 
 ![Routing precedence](images/basic-route-precedence-vs.png)
 
-Routing rules are evaluated in **sequential** order from top to bottom, with 
-the first rule in the virtual service definition being given highest priority. 
+Routing rules are evaluated in **sequential** order from top to bottom, with
+the first rule in the virtual service definition being given highest priority.
 
-Reorder the destination rules so that service `name-v1` will be evaluated 
+Reorder the destination rules so that service `name-v1` will be evaluated
 first and apply the changes.
 
 ```console
 kubectl apply -f 01-basic-traffic-routing/start/name-vs.yaml
 ```
 
-Go to **Graph** menu item in Kiali and select the **Versioned app graph** 
-from the drop down menu and observe the traffic flow.Traffic should once more 
+Go to **Graph** menu item in Kiali and select the **Versioned app graph**
+from the drop down menu and observe the traffic flow.Traffic should once more
 be routed to the `name-v1` service.
 
 ![Virtual service and destination rule](images/basic-route-vs.png)
@@ -370,37 +370,37 @@ be routed to the `name-v1` service.
 
 # Summary
 
-In this exercise you learned what a virtual service is and how to route traffic 
-to a destination service in kubernetes with an 
+In this exercise you learned what a virtual service is and how to route traffic
+to a destination service in kubernetes with an
 [HTTPRoute](https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPRoute).
 
 > Kubernetes only supports traffic distribution based on instance scaling. I.e. with the Kubernetes Service definition, we would need to scale the `name-v1` or `name-v2` Deployments to shift traffic.
 
-There is a lot more virtual services can do for traffic distribution like 
-match conditions for HTTPRoute on headers, uri, schemes, etc. HTTP redirects, 
+There is a lot more virtual services can do for traffic distribution like
+match conditions for HTTPRoute on headers, uri, schemes, etc. HTTP redirects,
 rewrites and more. We will looking at some of these in following exercises.
 
-See the [documentation](https://istio.io/latest/docs/reference/config/networking/virtual-service/#VirtualService) 
+See the [documentation](https://istio.io/latest/docs/reference/config/networking/virtual-service/#VirtualService)
 for more details.
 
-You also saw how a destination rule could be used to determine **what** 
-happens to traffic routed to a kubernetes service using labels identifying 
-workload versions. But you can also set **traffic policies** on a destination 
+You also saw how a destination rule could be used to determine **what**
+happens to traffic routed to a kubernetes service using labels identifying
+workload versions. But you can also set **traffic policies** on a destination
 rule to apply load balancing policies, connection pool settings, etc.
 
-See the [documentation](https://istio.io/latest/docs/reference/config/networking/destination-rule/#DestinationRule) 
+See the [documentation](https://istio.io/latest/docs/reference/config/networking/destination-rule/#DestinationRule)
 for more details.
 
 Main takeaways are:
 
-* A virtual services **hosts** field is a user addressable destination and can 
+* A virtual services **hosts** field is a user addressable destination and can
 be virtual.
 
-* A virtual services **destination** must exist. In Kubernetes this will 
+* A virtual services **destination** must exist. In Kubernetes this will
 be a Kubernetes Service.
 
-* A destination rule defines traffic policies that apply for the intended 
-service **after** routing has occurred with a virtual service. E.g. route 
+* A destination rule defines traffic policies that apply for the intended
+service **after** routing has occurred with a virtual service. E.g. route
 all traffic to v1, different load balancing modes for v1 and v2, etc.
 
 # Cleanup

--- a/02-deployment-patterns.md
+++ b/02-deployment-patterns.md
@@ -12,22 +12,22 @@
 - Mirror traffic for shadow deployment
 
 ## Introduction
-These exercises will introduce you to the match, weight and mirror fields of the 
-HTTPRoute. These fields and their combinations can be used to enable several 
-useful deployment patterns like blue/green deployments, canary deployments and 
+These exercises will introduce you to the match, weight and mirror fields of the
+HTTPRoute. These fields and their combinations can be used to enable several
+useful deployment patterns like blue/green deployments, canary deployments and
 shadow deployments.
 
 These exercises build on the [Basic traffic routing](01-basic-traffic-routing.md) exercises.
 
-> :bulb: If you have not completed exercise 
-> [00-setup-introduction](00-setup-introduction.md) you **need** to label 
+> :bulb: If you have not completed exercise
+> [00-setup-introduction](00-setup-introduction.md) you **need** to label
 > your namespace with `istio-injection=enabled`.
 
-## Exercise: Blue/Green Deployment 
+## Exercise: Blue/Green Deployment
 
-This exercise is going to introduce you to the HTTPRoute `match` field in a 
-virtual service. We want to implement a blue/green deployment pattern which 
-allows the **client** to actively select a version of the **name** service 
+This exercise is going to introduce you to the HTTPRoute `match` field in a
+virtual service. We want to implement a blue/green deployment pattern which
+allows the **client** to actively select a version of the **name** service
 it will hit.
 
 ```yaml
@@ -49,11 +49,11 @@ spec:
             subset: v2
 ```
 
-In the **example** above we define a HTTPMatchRequest with the field `match`. 
-The `headers` field declares that we want to match on **request** headers. 
+In the **example** above we define a HTTPMatchRequest with the field `match`.
+The `headers` field declares that we want to match on **request** headers.
 The `exact` field declares that the header **must** match exactly `use-v2`.
 
-Istio allows to use other parts of **incoming** requests and match them to values 
+Istio allows to use other parts of **incoming** requests and match them to values
 **you** define. To see what these are expand **More Info** below.
 
 <details>
@@ -82,15 +82,15 @@ headers is used uri, schema, method and authority are ignored.
 
 - **regex:** The **provided** value will be matched based on the regex
 
-**NOTE:** Istio regex's use the [re2](https://github.com/google/re2/wiki/Syntax) 
+**NOTE:** Istio regex's use the [re2](https://github.com/google/re2/wiki/Syntax)
 regular expression syntax
 
 </details>
 
-You can have multiple conditions in a match block and multiple match blocks. 
+You can have multiple conditions in a match block and multiple match blocks.
 
-> :bulb: All conditions inside a **single** match block have **AND** semantics, 
-> while the list of **match blocks** have **OR** semantics. The rule is matched 
+> :bulb: All conditions inside a **single** match block have **AND** semantics,
+> while the list of **match blocks** have **OR** semantics. The rule is matched
 > if any one of the match blocks succeed.
 
 **NOTE:** Matches are evaluated **prior** to any destination's being applied.
@@ -105,7 +105,7 @@ A general overview of what you will be doing in the **Step By Step** section.
 
 - Observe the traffic flow with Kiali
 
-- Route traffic to a specific version `v2` matching a header specified by the 
+- Route traffic to a specific version `v2` matching a header specified by the
 client
 
 ### Step by Step
@@ -126,7 +126,7 @@ kubectl apply -f 02-deployment-patterns/start/name-v1/
 kubectl apply -f 02-deployment-patterns/start/name-v2/
 ```
 
-This will deploy two versions of the **name** service along with a destination 
+This will deploy two versions of the **name** service along with a destination
 rule and virtual service as defined in a previous exercise.
 
 #### Task: Run the `scripts/loop-query.sh` script
@@ -143,10 +143,10 @@ ___
 ___
 
 
-In Kiali go to **graphs**, select **your** namespace and the 
+In Kiali go to **graphs**, select **your** namespace and the
 **versioned app graph**.
 
-You should see the traffic being routed to the `name-v1` workload because of 
+You should see the traffic being routed to the `name-v1` workload because of
 the precedence of the routes in the name virtual service.
 
 ![Precedence routing](images/kiali-precedence-routing.png)
@@ -163,8 +163,8 @@ Use `ctrl`+ `c` to stop the `loop-query.sh` script.
 ___
 
 
-Update the `name-vs.yaml` file with an 
-[HTTPMatchRequest](https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPMatchRequest) 
+Update the `name-vs.yaml` file with an
+[HTTPMatchRequest](https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPMatchRequest)
 and apply it.
 
 ```yaml
@@ -213,7 +213,7 @@ ___
 
 
 You should see all traffic being directed to `v2` of the name workload.
-That is because the match evaluated to true and the route **under** the 
+That is because the match evaluated to true and the route **under** the
 match block is used.
 
 ![Header based routing](images/kiali-blue-green.png)
@@ -223,7 +223,7 @@ match block is used.
 ___
 
 
-Use `ctrl`+ `c` to stop the `loop-query.sh` script and run it without passing 
+Use `ctrl`+ `c` to stop the `loop-query.sh` script and run it without passing
 the header.
 
 ```console
@@ -235,17 +235,17 @@ the header.
 ___
 
 
-You should now see all traffic being routed to `v1` of the name workload. 
-This is because when the match did **not** evaluate to true the default 
-route was used. 
+You should now see all traffic being routed to `v1` of the name workload.
+This is because when the match did **not** evaluate to true the default
+route was used.
 
-> Whenever you use matches for traffic routing. You should **always** ensure you 
+> Whenever you use matches for traffic routing. You should **always** ensure you
 > have a **default** route.
 
 ![Default route](images/kiali-default-destination.png)
 
-> :bulb: In the file `name-vs.yaml` you created. Notice the indentation for the 
-> route to `name-v1`, which is our **default** route. E.g the route to `name-v2` 
+> :bulb: In the file `name-vs.yaml` you created. Notice the indentation for the
+> route to `name-v1`, which is our **default** route. E.g the route to `name-v2`
 > is nested **under** the `match` block. That is a different route...
 
 #### Task: Remove the default route
@@ -287,12 +287,12 @@ kubectl apply -f 02-deployment-patterns/start/name-vs.yaml
 ___
 
 
-Go to Graph menu item and select the **Versioned app graph** from the drop 
+Go to Graph menu item and select the **Versioned app graph** from the drop
 down menu.
 
-The problem we have here is that the match is evaluated first **before** any 
-destination's are applied. Since the match was not true the route defined under 
-it was not applied. Nor have we provided another route to fall back on when the 
+The problem we have here is that the match is evaluated first **before** any
+destination's are applied. Since the match was not true the route defined under
+it was not applied. Nor have we provided another route to fall back on when the
 match does not evaluate to true.
 
 ![Missing default destination](images/kiali-no-default-destination.png)
@@ -335,11 +335,11 @@ spec:
 kubectl apply -f 02-deployment-patterns/start/name-vs.yaml
 ```
 
-Now try using a different header with the value `use-v2`. Modify the virtual 
-service to reflect the header you chose and pass the header to the 
+Now try using a different header with the value `use-v2`. Modify the virtual
+service to reflect the header you chose and pass the header to the
 loop-query.sh script.
 
-> You can call it anything you want. For example `x-version` is used 
+> You can call it anything you want. For example `x-version` is used
 > below but it really doesn't matter.
 
 ```console
@@ -351,14 +351,14 @@ loop-query.sh script.
 ___
 
 
-Go to Graph menu item and select the **Versioned app graph** from the drop 
+Go to Graph menu item and select the **Versioned app graph** from the drop
 down menu.
 
-In order for a match on a header to work it **must** be propagated to all the 
-services in the application tree. 
+In order for a match on a header to work it **must** be propagated to all the
+services in the application tree.
 
-As the header is **not** propagated to the name service the default route is hit. 
-> You would need to modify the sentence service to propagate the header onwards 
+As the header is **not** propagated to the name service the default route is hit.
+> You would need to modify the sentence service to propagate the header onwards
 > so the virtual service could match on it. If you look in the code for the
 > application, you can see which headers are currently forwarded.
 
@@ -368,32 +368,32 @@ As the header is **not** propagated to the name service the default route is hit
 
 ## Exercise: Canary Deployment
 
-This exercise is going to introduce you to the HTTPRoute `weight` field in a 
-virtual service. We want to implement a canary deployment pattern to the 
-**name** service's `v1` and `v2` workloads and **header** based blue/green 
+This exercise is going to introduce you to the HTTPRoute `weight` field in a
+virtual service. We want to implement a canary deployment pattern to the
+**name** service's `v1` and `v2` workloads and **header** based blue/green
 deployment to a `v3` workload.
 
 <details>
     <summary> More Info </summary>
 
-The canary deployment pattern is often employed **after** a blue/green deployment 
-pattern. Blue/green deployments are characterized by an **explicit** 
-choice by the **client/user** of which version to use. 
+The canary deployment pattern is often employed **after** a blue/green deployment
+pattern. Blue/green deployments are characterized by an **explicit**
+choice by the **client/user** of which version to use.
 
-A canary deployment removes the need for this explicit choice by **weighting** 
-the traffic between **releases**. But it is not an uncommon scenario to have a 
-canary deployment alongside of a blue/green deployment for the next 
+A canary deployment removes the need for this explicit choice by **weighting**
+the traffic between **releases**. But it is not an uncommon scenario to have a
+canary deployment alongside of a blue/green deployment for the next
 **unreleased** version.
 
 </details>
 
-Canary deployment is a pattern for rolling out **releases** to a **subset** 
-of users/clients. The idea is to test and gather feedback from this subset and 
+Canary deployment is a pattern for rolling out **releases** to a **subset**
+of users/clients. The idea is to test and gather feedback from this subset and
 reduce risk by gradually introducing a new release.
 
-> :laughing: Fun fact. The term canary comes from the coal mining industry 
-> where canaries were used to alert miners when toxic gases reached dangerous 
-> levels. In the same way canary deployments can alert you to issues, bad 
+> :laughing: Fun fact. The term canary comes from the coal mining industry
+> where canaries were used to alert miners when toxic gases reached dangerous
+> levels. In the same way canary deployments can alert you to issues, bad
 > design or whether features actually give the intended value.
 
 ```yaml
@@ -420,9 +420,9 @@ In the above example we define a traffic distribution percentage with
 the `weight` fields on the destinations of the HTTPRoute. The `v1`
 workload of `my-service` destination will receive 90% of **all**
 traffic while the `v2` workload of `my-service` will receive 10% of
-**all** traffic. 
+**all** traffic.
 
-> NB: Before `v1.13` of Istio, `weight` were thought to be percentages, 
+> NB: Before `v1.13` of Istio, `weight` were thought to be percentages,
 > and the sum of the `weight` fields across the
 > destinations of a single route `SHOULD BE == 100`.
 >
@@ -440,15 +440,15 @@ A general overview of what you will be doing in the **Step By Step** section.
 
 - Observe the traffic flow with Kiali
 
-- incorporate version `v3` of the name service in the destination rule and 
+- incorporate version `v3` of the name service in the destination rule and
 the virtual service for header based routing
 
 > The use case is that new version `v3` will be the new blue/green deployment.
 
-- Create a canary deployment for version `v1`and `v2` of the name service with 
+- Create a canary deployment for version `v1`and `v2` of the name service with
 the `weight` field
 
-> The use case is that `v2` has been validated and you are doing a canary 
+> The use case is that `v2` has been validated and you are doing a canary
 deployment to reduce risk.
 
 - Promote `v2` of the name service to receive **all** traffic.
@@ -523,10 +523,10 @@ spec:
         subset: name-v2
 ```
 
-> Again, notice the indentation. `name-v3` will only be hit if the header 
+> Again, notice the indentation. `name-v3` will only be hit if the header
 > match is true. The other two routes are evaluated top down.
-  
-> ❗ If you just did the blue/green exercise, 
+
+> ❗ If you just did the blue/green exercise,
 > make sure your routes to `name-v1` and `name-v2` are like above.
 
 ```console
@@ -548,11 +548,11 @@ If not already running, execute the `loop-query.sh` script.
 ___
 
 
-Go to Graph menu item and select the **Versioned app graph** from the drop 
+Go to Graph menu item and select the **Versioned app graph** from the drop
 down menu.
 
-The traffic should still be routed to the `v1` workload as the match condition 
-did not evaluate to true and order of precedence dictates the first destination 
+The traffic should still be routed to the `v1` workload as the match condition
+did not evaluate to true and order of precedence dictates the first destination
 which will direct traffic to `v1` workload.
 
 ![Precedence routing](images/kiali-bad-header.png)
@@ -594,7 +594,7 @@ spec:
       weight: 10                # and this
 ```
 
-> :bulb: The weight is distributed by **route** so the destination for `v2` must 
+> :bulb: The weight is distributed by **route** so the destination for `v2` must
 > be under the same route block.
 
 ```console
@@ -606,10 +606,10 @@ kubectl apply -f 02-deployment-patterns/start/name-vs.yaml
 ___
 
 
-Go to Graph menu item and select the **Versioned app graph** from the drop 
+Go to Graph menu item and select the **Versioned app graph** from the drop
 down menu.
 
-You should see that the traffic is distributed approximately 90% to `v1` and 10% 
+You should see that the traffic is distributed approximately 90% to `v1` and 10%
 to `v2`.
 
 ![90/10 traffic distribution](images/kiali-canary-anno.png)
@@ -630,14 +630,14 @@ ___
 
 You can see that the traffic distribution is no longer 90/10 between `v1` and `v2`.
 
-We have two clients. One has **all** traffic routed `v3`. The others traffic is 
+We have two clients. One has **all** traffic routed `v3`. The others traffic is
 distributed 90% to `v1` and 10% `v2`.
 
-The Kiali graph is showing you the percentage of the **overall** traffic. The 
+The Kiali graph is showing you the percentage of the **overall** traffic. The
 weight is applied to the traffic that hits the second route.
 
-Run `scripts/loop-query.sh` **without** the header in another terminal, or 
-several, and observe how it affects the traffic distribution. You will see the 
+Run `scripts/loop-query.sh` **without** the header in another terminal, or
+several, and observe how it affects the traffic distribution. You will see the
 percentage of the **overall** traffic change to look more like the 90/10 weight.
 
 ![90/10 distribution with Blue green](images/kiali-canary-blue-green.png)
@@ -669,7 +669,7 @@ spec:
       version: v3
 ```
 
-Remove the `name-v1` destination from `name-vs.yaml` file, adjust 
+Remove the `name-v1` destination from `name-vs.yaml` file, adjust
 the weight field to 100% on `name-v2` destination and apply changes.
 
 ```yaml
@@ -706,8 +706,8 @@ kubectl apply -f 02-deployment-patterns/start/name-vs.yaml
 
 ```
 
-> :bulb: You could simply adjust the weight values in the 
-> `name-vs.yaml` file. But for the next exercise it will cause 
+> :bulb: You could simply adjust the weight values in the
+> `name-vs.yaml` file. But for the next exercise it will cause
 > less confusion if the subsets and destinations are removed.
 
 > NB: do note that in the above we're removing a subset from the DestinationRule,
@@ -720,7 +720,7 @@ kubectl apply -f 02-deployment-patterns/start/name-vs.yaml
 > And when you're adding subsets, you want to update the DestinationRules first,
 > because we want the subsets to be there, before we're updating our VirtualServices.
 
-Finally, delete the `name-v1` workload. 
+Finally, delete the `name-v1` workload.
 
 ```console
 kubectl delete -f 02-deployment-patterns/start/name-v1/
@@ -731,7 +731,7 @@ kubectl delete -f 02-deployment-patterns/start/name-v1/
 ___
 
 
-All traffic will now be routed to the `v2` workload. Normally you would adjust 
+All traffic will now be routed to the `v2` workload. Normally you would adjust
 the weights gradually to expose `v2` to more and more users.
 
 ![Canary Promoted](images/kiali-canary-promoted.png)
@@ -740,34 +740,34 @@ the weights gradually to expose `v2` to more and more users.
 
 ## Exercise: Shadow Deployment
 
-This exercise will introduce you to the HTTPRoute `mirror` field in a virtual 
-service. We want to route traffic to the **name** service `v3` workload while 
-still forwarding traffic to the original destination. This is often called a 
+This exercise will introduce you to the HTTPRoute `mirror` field in a virtual
+service. We want to route traffic to the **name** service `v3` workload while
+still forwarding traffic to the original destination. This is often called a
 shadow deployment.
 
-> In Istio mirrored traffic is on a best effort basis. This means that the 
-> sidecar/gateway will **not** wait for mirrored traffic **before** sending 
+> In Istio mirrored traffic is on a best effort basis. This means that the
+> sidecar/gateway will **not** wait for mirrored traffic **before** sending
 > a response from the original destination.
 
-The use case here is the following. You have **completed** a canary deployment 
-for `v1` and `v2` of the **name** service. You have also done a blue/green 
-deployment for `v3` of the **name** service. You have tested it's functionality 
-and everything looks good. Now you would like to load test `v3` as it has some 
+The use case here is the following. You have **completed** a canary deployment
+for `v1` and `v2` of the **name** service. You have also done a blue/green
+deployment for `v3` of the **name** service. You have tested it's functionality
+and everything looks good. Now you would like to load test `v3` as it has some
 changes that could affect performance.
 
 <details>
     <summary> More Info </summary>
 
-The idea behind shadow deployments is that the clients/users have no idea about 
-the deployed version and the deployed version has **zero** impact on the 
-clients/users as the mirrored traffic happens out of band for the critical 
-request path for the primary service. 
+The idea behind shadow deployments is that the clients/users have no idea about
+the deployed version and the deployed version has **zero** impact on the
+clients/users as the mirrored traffic happens out of band for the critical
+request path for the primary service.
 
-Shadow deployments are particularly useful for load testing and refactoring of 
-monolithic applications. But they can be quite complex and care has to be taken 
-if there are interactions with other systems. Imagine shadow testing a payment 
-service for a shopping cart. You wouldn't want users paying twice for 
-an order. 
+Shadow deployments are particularly useful for load testing and refactoring of
+monolithic applications. But they can be quite complex and care has to be taken
+if there are interactions with other systems. Imagine shadow testing a payment
+service for a shopping cart. You wouldn't want users paying twice for
+an order.
 
 </details>
 
@@ -794,15 +794,15 @@ spec:
     mirrorPercentage:
       value: 100.0
 ```
-In the example above you can see that the `weight` field routes 100% of traffic 
-to the `v2` subset of `my-service`. The `mirror` field will route 100% of the 
-traffic `v2` receives to the `v3` subset. 
+In the example above you can see that the `weight` field routes 100% of traffic
+to the `v2` subset of `my-service`. The `mirror` field will route 100% of the
+traffic `v2` receives to the `v3` subset.
 
 
-Adjusting the `mirrorPercentage` value will adjust how much of the traffic 
-routed to `v2` will be mirrored to the `v3` subset. E.g, if set to 50.0 then 
-50% percent of traffic routed to the `v2` subset will be mirrored to the `v3` 
-subset. If the field is not defined then the `v3` subset will get 100% of the 
+Adjusting the `mirrorPercentage` value will adjust how much of the traffic
+routed to `v2` will be mirrored to the `v3` subset. E.g, if set to 50.0 then
+50% percent of traffic routed to the `v2` subset will be mirrored to the `v3`
+subset. If the field is not defined then the `v3` subset will get 100% of the
 traffic routed to `v2`.
 
 ### Overview
@@ -899,7 +899,7 @@ ___
 ./scripts/loop-query.sh
 ```
 
-You should **only** see responses from the `name-v2` workload. It should look 
+You should **only** see responses from the `name-v2` workload. It should look
 something like the following.
 
 ```
@@ -914,7 +914,7 @@ Athos (v2) is 92 years
 Porthos (v2) is 11 years
 Athos (v2) is 75 years
 ```
-> Requests mirrored to the `name-v3` workload are done as **fire and forget** 
+> Requests mirrored to the `name-v3` workload are done as **fire and forget**
 > requests. All **responses** are discarded.
 
 #### Task: Inspect the `name-v3` workload to see if it is receiving traffic
@@ -931,9 +931,9 @@ Get the logs with kubectl.
 
 ```console
 kubectl logs "$NAME_V3_POD" --tail=20 --follow
-``` 
+```
 
-You should see GET requests hitting the `name-v3` workload. It should look 
+You should see GET requests hitting the `name-v3` workload. It should look
 something like this.
 
 ```
@@ -955,15 +955,15 @@ WARNING:root:Operation 'name' took 0.238ms
 ___
 
 
-Go to Graph menu item and select the **Versioned app graph** from the drop 
+Go to Graph menu item and select the **Versioned app graph** from the drop
 down menu.
 
-If you look at the **version app graph** you **may** or **may not** see the 
+If you look at the **version app graph** you **may** or **may not** see the
 mirrored traffic being shown. It depends on the version of Kiali you are using.
 
 ![Graph with mirror](images/kiali-mirror-graph.png)
 
-But you know that the client is **not** getting 
+But you know that the client is **not** getting
 responses from `v3` from the terminals output.
 
 ```
@@ -979,12 +979,12 @@ Porthos (v2) is 11 years
 Athos (v2) is 75 years
 ```
 
-Go to the menu item **Workloads** and select `name-v3` and the **inbound** 
-metrics tab. 
+Go to the menu item **Workloads** and select `name-v3` and the **inbound**
+metrics tab.
 
-Metrics are also collected for the **destination** traffic of `v3`. If you 
-select **Source** from the **Reported from** drop down you will **not** 
-see any metrics as responses are discarded. 
+Metrics are also collected for the **destination** traffic of `v3`. If you
+select **Source** from the **Reported from** drop down you will **not**
+see any metrics as responses are discarded.
 
 ![Workload mirror metrics](images/kiali-mirrored-inbound-metrics.png)
 
@@ -994,11 +994,11 @@ see any metrics as responses are discarded.
 # Summary
 
 In these exercises you learned some of functionality provided by Istio's HTTPRoute.
-Implementing blue/green, canary and shadow deployment patterns. But there is a lot 
-more you can do. You can also manipulate headers, do HTTP redirects, 
-HTTP rewrites, etc. 
+Implementing blue/green, canary and shadow deployment patterns. But there is a lot
+more you can do. You can also manipulate headers, do HTTP redirects,
+HTTP rewrites, etc.
 
-See the [documentation](https://istio.io/latest/docs/reference/config/networking/virtual-service/#VirtualService) 
+See the [documentation](https://istio.io/latest/docs/reference/config/networking/virtual-service/#VirtualService)
 for a more complete overview of what you can do.
 
 The main takeaways are:
@@ -1011,7 +1011,7 @@ The main takeaways are:
 
 * You should always provide a default route when using a match
 
-* The **application** MUST propagate the headers in order for the virtual 
+* The **application** MUST propagate the headers in order for the virtual
 service to work with it
 
 # Cleanup

--- a/03-ingress-traffic.md
+++ b/03-ingress-traffic.md
@@ -10,44 +10,44 @@
 
 ## Introduction
 
-These exercises will introduce you to Istio concepts 
-and ([CRD's](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)) 
-for configuring traffic **into** the service mesh. This is commonly called 
-Ingress traffic. 
+These exercises will introduce you to Istio concepts
+and ([CRD's](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/))
+for configuring traffic **into** the service mesh. This is commonly called
+Ingress traffic.
 
-Istio does support 
-[Kubernetes Ingress](https://istio.io/latest/docs/tasks/traffic-management/ingress/kubernetes-ingress/) 
+Istio does support
+[Kubernetes Ingress](https://istio.io/latest/docs/tasks/traffic-management/ingress/kubernetes-ingress/)
 but also offers another configuration model.
 
-The Istio [IngressGateway](https://istio.io/latest/docs/tasks/traffic-management/ingress/ingress-control/) 
+The Istio [IngressGateway](https://istio.io/latest/docs/tasks/traffic-management/ingress/ingress-control/)
 which is what you will be using in this exercise.
 
-> :bulb: If you have not completed exercise 
-> [00-setup-introduction](00-setup-introduction.md) you **need** to label 
+> :bulb: If you have not completed exercise
+> [00-setup-introduction](00-setup-introduction.md) you **need** to label
 > your namespace with `istio-injection=enabled`.
 
 ## Exercise: Ingress Traffic With Gateway
 
-The previous exercises used a Kubernetes **NodePort** service to get traffic 
-to the sentences service. E.g. the **ingress** traffic to `sentences` **was 
-not** flowing through the Istio service mesh. 
+The previous exercises used a Kubernetes **NodePort** service to get traffic
+to the sentences service. E.g. the **ingress** traffic to `sentences` **was
+not** flowing through the Istio service mesh.
 
-From the `sentences` service to the `age` and `name` services traffic **was** 
-flowing through the Istio service mesh. We know this to be true because we 
+From the `sentences` service to the `age` and `name` services traffic **was**
+flowing through the Istio service mesh. We know this to be true because we
 have applied virtual services and destination rules to the `name` service.
 
 Ingressing traffic directly from the Kubernetes cluster network to a frontend
-service means that Istio features **cannot** be applied on this part of the 
+service means that Istio features **cannot** be applied on this part of the
 traffic flow.
 
-In this exercise you are going rectify this by **configuring** ingress traffic 
-to the sentences service through a dedicated **IngressGateway** (`istio-ingressgateway`) 
-provided by **Istio** instead of a Kubernetes NodePort. Furthermore you are going 
-to introduce a fixed delay to demonstrate that you can now apply Istio traffic 
+In this exercise you are going rectify this by **configuring** ingress traffic
+to the sentences service through a dedicated **IngressGateway** (`istio-ingressgateway`)
+provided by **Istio** instead of a Kubernetes NodePort. Furthermore you are going
+to introduce a fixed delay to demonstrate that you can now apply Istio traffic
 management to the sentences service.
 
-You are going to do this using the 
-[Gateway](https://istio.io/latest/docs/reference/config/networking/gateway/#Gateway) 
+You are going to do this using the
+[Gateway](https://istio.io/latest/docs/reference/config/networking/gateway/#Gateway)
 CRD which will **configure** an **entry point** in the Istio **IngressGateway**.
 
 > **Expand the example below for more details.**
@@ -77,32 +77,32 @@ spec:
 and the hosts exposed by the gateway. A host entry is specified as a DNS name
 and should be specified using the FQDN format.
 
-  > You can use a wildcard character in the **left-most** component of the 
-  > `hosts` field. E.g. `*.example.com`. 
-  > 
-  > You can also **prefix** the `hosts` field with a namespace. See the 
+  > You can use a wildcard character in the **left-most** component of the
+  > `hosts` field. E.g. `*.example.com`.
+  >
+  > You can also **prefix** the `hosts` field with a namespace. See the
   > [documentation](https://istio.io/latest/docs/reference/config/networking/gateway/#Server) for more details.
 
-- The **selectors** above are the labels on the `istio-ingressgateway` POD which 
+- The **selectors** above are the labels on the `istio-ingressgateway` POD which
 is the IngressGateway the traffic will be routed through.
 
-> Don't confuse the the **IngressGateway** with the Gateway custom resource 
+> Don't confuse the the **IngressGateway** with the Gateway custom resource
 > definition. The gateway CRD is used to **configure** the Ingressgateway.
-> The gateway defines and **entry point** to be exposed in the 
+> The gateway defines and **entry point** to be exposed in the
 > `istio-ingressgateway`. That is it. Nothing else.
 
 
 <details>
     <summary> More About IngressGateways </summary>
 
-An Istio **IngressGateway** **describes** a load balancer operating at the 
+An Istio **IngressGateway** **describes** a load balancer operating at the
 **edge** of the mesh receiving incoming or outgoing **HTTP/TCP** connections.
 
-An Istio **IngressGateway** in a Kubernetes cluster consists, at a minimum, 
-of a Deployment and a Service. Istio ingress gateways are based on Envoy 
-and have a **standalone** Envoy proxy. 
+An Istio **IngressGateway** in a Kubernetes cluster consists, at a minimum,
+of a Deployment and a Service. Istio ingress gateways are based on Envoy
+and have a **standalone** Envoy proxy.
 
-In our course environment we have an Istio **IngressGateway** in it's own 
+In our course environment we have an Istio **IngressGateway** in it's own
 namespace `istio-ingress`.
 
 This is the IngressGateway which we configure with a Gateway CRD.
@@ -112,9 +112,9 @@ This is the IngressGateway which we configure with a Gateway CRD.
 </details>
 
 
-In order to route the traffic we, of course, use a **virtual service**. The entry 
-point you configure with a GateWay CRD knows nothing about how to route the 
-traffic to the desired destination within the mesh. Therefor you use a virtual 
+In order to route the traffic we, of course, use a **virtual service**. The entry
+point you configure with a GateWay CRD knows nothing about how to route the
+traffic to the desired destination within the mesh. Therefor you use a virtual
 service specifying the **gateway** you defined.
 
 > **Expand the example below for more details.**
@@ -138,9 +138,9 @@ spec:
         host: myapp-frontend
 ```
 
-Note how it specifies the hostname and the name of the gateway 
-(in `spec.gateways`). A gateway definition can define an entry for many 
-hostnames and a VirtualService can be bound to multiple gateways, i.e. these 
+Note how it specifies the hostname and the name of the gateway
+(in `spec.gateways`). A gateway definition can define an entry for many
+hostnames and a VirtualService can be bound to multiple gateways, i.e. these
 are not necessarily related one-to-one.
 
 </details>
@@ -155,10 +155,10 @@ A general overview of what you will be doing in the **Step By Step** section.
 
 - Create an entry point for the sentences service
 
-> :bulb: In the yaml provided in the **Step By Step** section notice the 
-> placeholder environment variables (`$STUDENT_NS` and `$TRAINING_NAME`). 
-> When applying these you will be using the `envsubst` command to replace them 
-> with the values provided in the environment. 
+> :bulb: In the yaml provided in the **Step By Step** section notice the
+> placeholder environment variables (`$STUDENT_NS` and `$TRAINING_NAME`).
+> When applying these you will be using the `envsubst` command to replace them
+> with the values provided in the environment.
 
 - Create a route from the entry point to the sentences service
 
@@ -186,7 +186,7 @@ kubectl apply -f 03-ingress-traffic/start/
 ___
 
 
-Create a file called `sentences-ingress-gw.yaml` in 
+Create a file called `sentences-ingress-gw.yaml` in
 `03-ingress-traffic/start` directory.
 
 It should look like the below yaml.
@@ -220,7 +220,7 @@ envsubst < 03-ingress-traffic/start/sentences-ingress-gw.yaml | kubectl apply -f
 ___
 
 
-Create a file called `sentences-ingress-vs.yaml` in 
+Create a file called `sentences-ingress-vs.yaml` in
 `03-ingress-traffic/start` directory.
 
 It should look like the below yaml.
@@ -251,7 +251,7 @@ Substitute the environment variable(s) and apply the output with kubectl.
 envsubst < 03-ingress-traffic/start/sentences-ingress-vs.yaml | kubectl apply -f -
 ```
 
-> :bulb: If you want or need to do an environment substitution on multiple files 
+> :bulb: If you want or need to do an environment substitution on multiple files
 > you can use a for loop to do so.
 > `for file in 03-ingress-traffic/start/*.yaml; do envsubst < $file | kubectl apply -f -; done`
 
@@ -260,8 +260,8 @@ envsubst < 03-ingress-traffic/start/sentences-ingress-vs.yaml | kubectl apply -f
 ___
 
 
-The sentence service we deployed in the first step has a type of `ClusterIP` 
-now. In order to reach it we will need to go through the `istio-ingressgateway`. 
+The sentence service we deployed in the first step has a type of `ClusterIP`
+now. In order to reach it we will need to go through the `istio-ingressgateway`.
 
 Run the `loop-query.sh` script with the option `-g` and pass it the `hosts` entry.
 
@@ -274,11 +274,11 @@ Run the `loop-query.sh` script with the option `-g` and pass it the `hosts` entr
 ___
 
 
-Go to Graph menu item and select the **Versioned app graph** from the drop 
+Go to Graph menu item and select the **Versioned app graph** from the drop
 down menu.
 
-Now we can see that the traffic to the `sentences` service is no longer 
-**unknown** to the service mesh. 
+Now we can see that the traffic to the `sentences` service is no longer
+**unknown** to the service mesh.
 
 ![Ingress Gateway](images/kiali-ingress-gw.png)
 
@@ -287,8 +287,8 @@ Now we can see that the traffic to the `sentences` service is no longer
 ___
 
 
-To demonstrate that we can now apply Istio traffic management to the 
-sentences service. Add a fixed delay of 5 seconds to the 
+To demonstrate that we can now apply Istio traffic management to the
+sentences service. Add a fixed delay of 5 seconds to the
 `sentences-ingress-vs.yaml` file you created.
 
 ```yaml
@@ -318,7 +318,7 @@ Substitute the environment variable(s) and apply the output with kubectl.
 envsubst < 03-ingress-traffic/start/sentences-ingress-vs.yaml | kubectl apply -f -
 ```
 
-You should see that the response in the terminal are now taking 
+You should see that the response in the terminal are now taking
 approximately five seconds each.
 
 #### Task: Observe the traffic flow with Kiali
@@ -326,17 +326,17 @@ approximately five seconds each.
 ___
 
 
-Go to **Workloads** menu item, select `sentences-v1` workload and the 
-**Inbound Metrics** tab, **Reported from** in the **Source** drop down 
-menu and select checkboxes as shown in the below image. 
+Go to **Workloads** menu item, select `sentences-v1` workload and the
+**Inbound Metrics** tab, **Reported from** in the **Source** drop down
+menu and select checkboxes as shown in the below image.
 
 ![Sentences delay](images/kiali-sentences-fixed-delay.png)
 
-It may take a little bit before the graph updates but, eventually, you 
+It may take a little bit before the graph updates but, eventually, you
 should see that the request duration is trending towards five seconds.
 
 Similarly, the versioned graph view can show the 95th percentile of response times:
-    
+
 > ❗ NB: only some versions of Kiali show the fault-injection response times.
 
 ![Sentences delay](images/kiali-sentences-fixed-delay-versioned-graph.png)
@@ -346,25 +346,25 @@ Similarly, the versioned graph view can show the 95th percentile of response tim
 
 # Summary
 
-In this exercise you saw how to route incoming traffic through an ingress gateway. 
-This allows you to apply istio traffic management features to the sentences 
-service. For example, you could do a blue/green deploy of two different versions 
+In this exercise you saw how to route incoming traffic through an ingress gateway.
+This allows you to apply istio traffic management features to the sentences
+service. For example, you could do a blue/green deploy of two different versions
 of the sentence service.
 
-Istio's default installation provide it's own configuration model (Gateway) 
-for ingress traffic while also supporting Kubernetes ingress. The Istio  
+Istio's default installation provide it's own configuration model (Gateway)
+for ingress traffic while also supporting Kubernetes ingress. The Istio
 gateway consists of a deployment, a service and a **standalone** envoy proxy.
 
-> The ingress gateway we used in our training environment is located in the 
+> The ingress gateway we used in our training environment is located in the
 > `istio-ingress` namespace.
 
 The main takeaways are:
 
-* When you defined the gateway CRD for your namespace you configured an entry 
+* When you defined the gateway CRD for your namespace you configured an entry
 point in the standalone envoy proxy
 
-* If traffic is not flowing through the mesh, e.g through the envoy sidecars, 
-then you cannot leverage Istio features, e.g. the traffic between the gateway 
+* If traffic is not flowing through the mesh, e.g through the envoy sidecars,
+then you cannot leverage Istio features, e.g. the traffic between the gateway
 and your frontend service
 
 # Cleanup

--- a/04-egress-traffic.md
+++ b/04-egress-traffic.md
@@ -11,56 +11,56 @@
 
 ## Introduction
 
-This exercise will introduce you to Istio concepts 
-and ([CRD's](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)) 
-for configuring traffic **out** of the service mesh. This is commonly 
+This exercise will introduce you to Istio concepts
+and ([CRD's](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/))
+for configuring traffic **out** of the service mesh. This is commonly
 called Egress traffic.
 
-There are two Istio CRD's in addition to a virtual service needed for this. 
-The [Gateway](https://istio.io/latest/docs/reference/config/networking/gateway/#Gateway) 
-and the [ServiceEntry](https://istio.io/latest/docs/reference/config/networking/service-entry/#ServiceEntry) 
-CRD's. 
+There are two Istio CRD's in addition to a virtual service needed for this.
+The [Gateway](https://istio.io/latest/docs/reference/config/networking/gateway/#Gateway)
+and the [ServiceEntry](https://istio.io/latest/docs/reference/config/networking/service-entry/#ServiceEntry)
+CRD's.
 
-First you will route traffic **directly** to an external service from an internal 
-service with a service entry. Then you will route traffic from an internal 
-service through a common egress gateway. 
+First you will route traffic **directly** to an external service from an internal
+service with a service entry. Then you will route traffic from an internal
+service through a common egress gateway.
 
 This exercise builds on the [Getting Traffic Into The mesh](03-ingress-traffic.md) exercises.
 
-> :bulb: If you have not completed exercise 
-> [00-setup-introduction](00-setup-introduction.md) you **need** to label 
+> :bulb: If you have not completed exercise
+> [00-setup-introduction](00-setup-introduction.md) you **need** to label
 > your namespace with `istio-injection=enabled`.
 
 ## Exercise: Egress Traffic
 
-In this exercise you will deploy a **new** version of the **sentences** 
-service. This new version will use a new **API** service which does nothing 
-more than make a call to an external service ([httpbin](https://httpbin.org/)) 
-asking for a delay of 1 second for responses. You will then define a ServiceEntry 
-to allow traffic to the external service. After you have successfully reached 
+In this exercise you will deploy a **new** version of the **sentences**
+service. This new version will use a new **API** service which does nothing
+more than make a call to an external service ([httpbin](https://httpbin.org/))
+asking for a delay of 1 second for responses. You will then define a ServiceEntry
+to allow traffic to the external service. After you have successfully reached
 httpbin you will route the traffic through a common egress gateway.
 
 ### Service Entry
 
-A ServiceEntry allows you to apply Istio traffic management for services 
-running **outside** of your mesh. Your service might use an external API 
-as an example. Once you have defined a service entry you can configure 
-virtual services and destination rules to apply Istio features like 
-redirecting or forwarding traffic to external destinations, defining 
-retries, timeouts and fault injection policies. 
+A ServiceEntry allows you to apply Istio traffic management for services
+running **outside** of your mesh. Your service might use an external API
+as an example. Once you have defined a service entry you can configure
+virtual services and destination rules to apply Istio features like
+redirecting or forwarding traffic to external destinations, defining
+retries, timeouts and fault injection policies.
 
-> :bulb: In our environment we have set the outBoundTrafficPolicy to 
+> :bulb: In our environment we have set the outBoundTrafficPolicy to
 > `REGISTRY_ONLY`.
 
-By default, Istio configures Envoy proxies to **passthrough** requests to 
-unknown services. So, technically service entries are not required. But 
-without them you can't apply Istio features as the external service will be 
+By default, Istio configures Envoy proxies to **passthrough** requests to
+unknown services. So, technically service entries are not required. But
+without them you can't apply Istio features as the external service will be
 a black hole to the service mesh.
 
-There is also the security aspect to consider. While securely controlling 
-ingress traffic is the **highest** priority, it is good policy to securely 
-control egress traffic also. Because of this many clusters will have the 
-`outBoundTrafficPolicy` set to `REGISTRY_ONLY` as is done in our cluster. 
+There is also the security aspect to consider. While securely controlling
+ingress traffic is the **highest** priority, it is good policy to securely
+control egress traffic also. Because of this many clusters will have the
+`outBoundTrafficPolicy` set to `REGISTRY_ONLY` as is done in our cluster.
 This will force you to define your external services with a service entry.
 
 > **Expand the example below for more details.**
@@ -93,36 +93,36 @@ and destination rules. The `resolution` field is used to determine how the
 proxy will resolve IP addresses of the end points. The `exportTo` field scopes
 the service entry to the namespace where it is defined
 
-> :bulb: The `exportTo` field is important for this exercise. **Not** 
-> scoping the service entry to your namespace will open the external 
-> service for **all** attendees. 
+> :bulb: The `exportTo` field is important for this exercise. **Not**
+> scoping the service entry to your namespace will open the external
+> service for **all** attendees.
 
-When you create a service entry it is added to Istio's internal service 
-registry and traffic is allowed out of the mesh to the defined destination. 
+When you create a service entry it is added to Istio's internal service
+registry and traffic is allowed out of the mesh to the defined destination.
 
-Istio maintains an internal service registry containing the set of services, 
-and their corresponding service endpoints, running in a service mesh. 
+Istio maintains an internal service registry containing the set of services,
+and their corresponding service endpoints, running in a service mesh.
 Istio uses the service registry to generate Envoy configuration.
 
-> Istio does not provide service discovery, although most services are 
-> automatically added to the registry by Pilot adapters that reflect the 
-> discovered services of the underlying platform (Kubernetes, Consul, plain DNS). 
-> Additional services can also be registered manually using a ServiceEntry 
+> Istio does not provide service discovery, although most services are
+> automatically added to the registry by Pilot adapters that reflect the
+> discovered services of the underlying platform (Kubernetes, Consul, plain DNS).
+> Additional services can also be registered manually using a ServiceEntry
 > configuration.
 
 </details>
 
 ### Gateway
 
-Once a service entry is defined the traffic flows **directly** from the 
-workloads Envoy sidecar to the external service. 
+Once a service entry is defined the traffic flows **directly** from the
+workloads Envoy sidecar to the external service.
 
-But it is a pretty common use cases to have traffic leaving the mesh 
+But it is a pretty common use cases to have traffic leaving the mesh
 routed **via** a common **egress** gateway.
 
-A Gateway **describes** a load balancer operating at the **edge** of the mesh 
-receiving incoming or outgoing **HTTP/TCP** connections. The specification 
-describes the ports to be expose, type of protocol, configuration for the 
+A Gateway **describes** a load balancer operating at the **edge** of the mesh
+receiving incoming or outgoing **HTTP/TCP** connections. The specification
+describes the ports to be expose, type of protocol, configuration for the
 load balancer, etc.
 
 > **Expand the example below for more details.**
@@ -148,25 +148,25 @@ spec:
     - external-api.example.com
 ```
 
-The fields are the same as for the gateway defined for Ingress traffic to 
-the sentences service in a previous exercise. The notable difference being 
-that the **selectors** are now the labels on the **Egress** POD 
-`istio-egressgateway`, which is also running a standalone Envoy proxy just like 
+The fields are the same as for the gateway defined for Ingress traffic to
+the sentences service in a previous exercise. The notable difference being
+that the **selectors** are now the labels on the **Egress** POD
+`istio-egressgateway`, which is also running a standalone Envoy proxy just like
 the ingress gateway.
 
-The gateway defines an **exit point** to be exposed in the `istio-egressgateway`. 
-That is it. Nothing else. Just like an ingress entry point, it knows nothing 
-about how traffic is routed to it. 
+The gateway defines an **exit point** to be exposed in the `istio-egressgateway`.
+That is it. Nothing else. Just like an ingress entry point, it knows nothing
+about how traffic is routed to it.
 
-An Istio **Egress** gateway in a Kubernetes cluster consists, at a minimum, of a 
-Deployment and a Service. Istio egress gateways are based on Envoy and have a 
-**standalone** Envoy proxy. 
+An Istio **Egress** gateway in a Kubernetes cluster consists, at a minimum, of a
+Deployment and a Service. Istio egress gateways are based on Envoy and have a
+**standalone** Envoy proxy.
 
 Our course environment would show something like:
 
 ```
-NAME                                       TYPE                                   
-istio-egressgateway                        deployment  
+NAME                                       TYPE
+istio-egressgateway                        deployment
 istio-egressgateway                        service
 istio-egressgateway-8679c48588-2p8vw       pod
 ```
@@ -180,7 +180,7 @@ istio-egressgateway-8679c48588-2p8vw    istio-proxy
 
 </details>
 
-In order to route the traffic we, of course, use a virtual service. The gateway 
+In order to route the traffic we, of course, use a virtual service. The gateway
 just defines the **exit point** and we still need to define the route.
 
 > **Expand the example below for more details.**
@@ -213,18 +213,18 @@ spec:
       weight: 100
 ```
 
-- The route uses the reserved keyword `mesh` implying that this rule applies 
-to the sidecars in the mesh. 
+- The route uses the reserved keyword `mesh` implying that this rule applies
+to the sidecars in the mesh.
 
 - The exportTo field ensures the virtual service is applied only to the present
-namespace. 
+namespace.
 
 - The **full DNS name** of the `istio-egressgateway` service is defined instead
 of the shortname because the gateway is located in the `istio-system` namespace.
 
-> :bulb: Istio will translate a **short name** based one the **namespace** of the 
-> **rule**, e.g. if the virtual service is in the `default` namespace it will 
-> translate to `istio-egressgateway.default.svc.cluster.local`. So **full names** 
+> :bulb: Istio will translate a **short name** based one the **namespace** of the
+> **rule**, e.g. if the virtual service is in the `default` namespace it will
+> translate to `istio-egressgateway.default.svc.cluster.local`. So **full names**
 > should be used when using a gateway in another namespace.
 
 </details>
@@ -243,10 +243,10 @@ A general overview of what you will be doing in the **Step By Step** section.
 
 - Modify the the virtual service to route traffic through the **common** gateway
 
-> :bulb: The exit point for [httpbin](http://httpbin.org) and needed routes to 
-> the `istio-egressgateway` have already been created in the `istio-system` 
-> namespace. The role based access control (RBAC) in our training environment 
-> does **not** permit attendees to create resources in the `istio-system` 
+> :bulb: The exit point for [httpbin](http://httpbin.org) and needed routes to
+> the `istio-egressgateway` have already been created in the `istio-system`
+> namespace. The role based access control (RBAC) in our training environment
+> does **not** permit attendees to create resources in the `istio-system`
 > namespace.
 
 - Observe the traffic flow with Kiali
@@ -263,7 +263,7 @@ Expand the **Tasks** section below to do the exercise.
 ___
 
 
-Deploy `v2` of the sentences application services which has a new api service 
+Deploy `v2` of the sentences application services which has a new api service
 along with the ingress gateway entry point and virtual service.
 
 ```console
@@ -276,7 +276,7 @@ Make sure everything is in ready state.
 kubectl get gateway,se,vs,dr,svc,pods -n $STUDENT_NS
 ```
 
-You should now see a gateway, two virtual services and a destination rule along 
+You should now see a gateway, two virtual services and a destination rule along
 with four services and pods running. It should look something like below.
 
 ```
@@ -317,7 +317,7 @@ ___
 ___
 
 
-Export the pod as an environment variable. 
+Export the pod as an environment variable.
 
 ```console
 export API_POD=$(kubectl get pod -l app=sentences,mode=api -o jsonpath={.items..metadata.name})
@@ -329,7 +329,7 @@ Now tail the logs.
 kubectl logs "$API_POD" --tail=20 --follow
 ```
 
-You should see a response of 502(Bad Gateway) because there exists no service entry for 
+You should see a response of 502(Bad Gateway) because there exists no service entry for
 the external service httpbin.
 
 ```
@@ -343,12 +343,12 @@ WARNING:root:Operation 'api' took 306.376ms
 ___
 
 
-Go to Graph menu item and select the **Versioned app graph** from the drop 
+Go to Graph menu item and select the **Versioned app graph** from the drop
 down menu.
 
 ![No Service Entry](images/kiali-api-no-se.png)
 
-As there is no service entry all traffic to the external service is blocked 
+As there is no service entry all traffic to the external service is blocked
 and it is a **black hole** to the service mesh.
 
 #### Task: Define a service entry for httpbin.org
@@ -356,7 +356,7 @@ and it is a **black hole** to the service mesh.
 ___
 
 
-Create a service entry called `api-egress-se.yaml` in 
+Create a service entry called `api-egress-se.yaml` in
 `04-egress-traffic/start/`.
 
 ```yaml
@@ -408,12 +408,12 @@ WARNING:root:Operation 'api' took 1073.259ms
 ___
 
 
-Go to Graph menu item and select the **Versioned app graph** from the drop 
+Go to Graph menu item and select the **Versioned app graph** from the drop
 down menu.
 
 ![Service Entry](images/kiali-api-se.png)
 
-Now Kiali recognizes the external service because of the service entry and it 
+Now Kiali recognizes the external service because of the service entry and it
 is no longer a black hole.
 
 #### Task: Create a virtual service with a timeout of 0.5 seconds
@@ -421,14 +421,14 @@ is no longer a black hole.
 ___
 
 
-Basically all we have done so far is to add an entry for httpbin to Istio's 
-internal service registry. But we can now apply some of the Istio features to 
-the external service. To demonstrate this you will create a virtual service for 
+Basically all we have done so far is to add an entry for httpbin to Istio's
+internal service registry. But we can now apply some of the Istio features to
+the external service. To demonstrate this you will create a virtual service for
 traffic to httpbin with a timeout of `0.5s`.
 
 > The api service asks httpbin.org for a response delay of 1 second and since we are now enforcing a local timeout of 0.5s we are basically configuring the external call to timeout!
 
-Create a file called `api-egress-vs.yaml` in 
+Create a file called `api-egress-vs.yaml` in
 `04-egress-traffic/start/`.
 
 ```yaml
@@ -465,7 +465,7 @@ Tail the logs.
 kubectl logs "$API_POD" --tail=20 --follow
 ```
 
-Now you should be getting a 504(Gateway Timeout) response from the external service. 
+Now you should be getting a 504(Gateway Timeout) response from the external service.
 
 ```
 INFO:werkzeug:127.0.0.1 - - [10/Aug/2021 13:29:11] "GET / HTTP/1.1" 200 -
@@ -501,7 +501,7 @@ spec:
       port: 80
     route:
     - destination:
-        host: istio-egressgateway.istio-system.svc.cluster.local        
+        host: istio-egressgateway.istio-system.svc.cluster.local
         port:
           number: 80
       weight: 100
@@ -536,14 +536,14 @@ WARNING:root:Operation 'api' took 1080.768ms
 ___
 
 
-Go to Graph menu item and select the **Versioned app graph** from the drop 
+Go to Graph menu item and select the **Versioned app graph** from the drop
 down menu. Select the checkboxes as shown in the below image.
 
-You will see traffic to the sentences service entering through the ingress 
-gateway in the `istio-ingress` namespace. Traffic from the api service is now 
+You will see traffic to the sentences service entering through the ingress
+gateway in the `istio-ingress` namespace. Traffic from the api service is now
 leaving through the common egress gateway in the `istio-system` namespace.
 
-> Note depending on the version of Kiali in use the graph may look disconnected 
+> Note depending on the version of Kiali in use the graph may look disconnected
 > between the api service and the external service.
 
 ![API Egress](images/kiali-api-egress.png)
@@ -552,26 +552,26 @@ leaving through the common egress gateway in the `istio-system` namespace.
 
 # Summary
 
-In this exercise you created a service entry to allow access to an 
-external service. This is a pretty common use case. A lot of service 
-meshes will have a `REGISTRY_ONLY` policy defined for security reasons. 
+In this exercise you created a service entry to allow access to an
+external service. This is a pretty common use case. A lot of service
+meshes will have a `REGISTRY_ONLY` policy defined for security reasons.
 So you should be aware of what a service entry does.
 
-Afterwards you created a virtual service to demonstrate Istio traffic 
-management for traffic to an external service. Finally, you routed the 
-traffic to the external service through a **common** egress gateway. 
+Afterwards you created a virtual service to demonstrate Istio traffic
+management for traffic to an external service. Finally, you routed the
+traffic to the external service through a **common** egress gateway.
 
 The main takeaways are:
 
-- If traffic is **not** flowing through the mesh, e.g through the 
-envoy sidecars, then you cannot leverage Istio features. Regardless 
+- If traffic is **not** flowing through the mesh, e.g through the
+envoy sidecars, then you cannot leverage Istio features. Regardless
 of whether it is ingress or egress traffic.
 
-- Service entries are needed if the **default** passthrough logic to 
+- Service entries are needed if the **default** passthrough logic to
 external service is disabled.
 
-- Gateways define an exit point for load balancer operating at the edge of 
-the mesh. You still need to route traffic to the gateway and the external 
+- Gateways define an exit point for load balancer operating at the edge of
+the mesh. You still need to route traffic to the gateway and the external
 service.
 
 # Cleanup

--- a/05-securing-with-mtls.md
+++ b/05-securing-with-mtls.md
@@ -15,31 +15,31 @@ These exercises will demonstrate how to use mutual TLS inside the mesh between
 PODs with the Istio sidecar injected and also from mesh-external services
 accessing the mesh through an ingress gateway.
 
-You will be using several Istio custom resource 
-definitions([CRD's](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)) 
+You will be using several Istio custom resource
+definitions([CRD's](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/))
 for this.
 
-- [PeerAuthentication](https://istio.io/latest/docs/reference/config/security/peer_authentication/#PeerAuthentication-MutualTLS) - 
+- [PeerAuthentication](https://istio.io/latest/docs/reference/config/security/peer_authentication/#PeerAuthentication-MutualTLS) -
 Applies to requests that a service **receives**
 
-- [DestinationRule](https://istio.io/latest/docs/reference/config/networking/destination-rule/#DestinationRule) - 
+- [DestinationRule](https://istio.io/latest/docs/reference/config/networking/destination-rule/#DestinationRule) -
 What type of TLS sidecar **sends**
 
-- [Gateway](https://istio.io/latest/docs/reference/config/networking/gateway/#ServerTLSSettings) - 
+- [Gateway](https://istio.io/latest/docs/reference/config/networking/gateway/#ServerTLSSettings) -
 Specify TLS settings for external service
 
-Istio provides two types of authentication policies of which *peer 
-authentication* is one of them. 
+Istio provides two types of authentication policies of which *peer
+authentication* is one of them.
 
-Peer authentication is used for **service-to-service** authentication 
-to verify the client making the connection and secure the 
-service-to-service communication. Istio uses 
-[mutual TLS](https://en.wikipedia.org/wiki/Mutual_authentication)(mTLS) 
-for transport authentication. 
+Peer authentication is used for **service-to-service** authentication
+to verify the client making the connection and secure the
+service-to-service communication. Istio uses
+[mutual TLS](https://en.wikipedia.org/wiki/Mutual_authentication)(mTLS)
+for transport authentication.
 
-This provides a **strong identity** for each workload. 
+This provides a **strong identity** for each workload.
 
-> Istio has it's own certificate authority(CA) and securely provisions strong 
+> Istio has it's own certificate authority(CA) and securely provisions strong
 > identities to every workload with X.509 certificates.
 
 <details>
@@ -49,30 +49,30 @@ Istio provisions keys and certificates through the following flow:
 
 - istiod offers a gRPC service to take certificate signing requests (CSRs).
 
-- When started, the Istio agent creates the private key and CSR, and then 
+- When started, the Istio agent creates the private key and CSR, and then
 sends the CSR with its credentials to istiod for signing.
 
-- The CA in istiod validates the credentials carried in the CSR. Upon 
+- The CA in istiod validates the credentials carried in the CSR. Upon
 successful validation, it signs the CSR to generate the certificate.
 
-- When a workload is started, Envoy requests the certificate and key from 
-the Istio agent in the same container via the Envoy secret discovery 
+- When a workload is started, Envoy requests the certificate and key from
+the Istio agent in the same container via the Envoy secret discovery
 service (SDS) API.
 
-- The Istio agent sends the certificates received from istiod and the private 
+- The Istio agent sends the certificates received from istiod and the private
 key to Envoy via the Envoy SDS API.
 
-- Istio agent monitors the expiration of the workload certificate. 
+- Istio agent monitors the expiration of the workload certificate.
 
 > The above process repeats periodically for certificate and key rotation.
 
 </details>
 
-Peer authentication is normally enabled at the `mesh` level, as in our 
-training infrastructure, which means traffic is secured by **default** 
-for all services in the cluster **without** requiring code changes. 
+Peer authentication is normally enabled at the `mesh` level, as in our
+training infrastructure, which means traffic is secured by **default**
+for all services in the cluster **without** requiring code changes.
 
-There are four modes that can be set for mTLS. They are `UNSET`, `DISABLE`, 
+There are four modes that can be set for mTLS. They are `UNSET`, `DISABLE`,
 `PERMISSIVE` and `STRICT`.
 
 <details>
@@ -80,7 +80,7 @@ There are four modes that can be set for mTLS. They are `UNSET`, `DISABLE`,
 
 - `UNSET` - Modes is inherited from parent, defaults to PERMISSIVE
 
-- `DISABLE` - Connection is **not** tunneled 
+- `DISABLE` - Connection is **not** tunneled
 
 - `PERMISSIVE` - Connection can be either plaintext or mTLS tunnel
 
@@ -90,21 +90,21 @@ There are four modes that can be set for mTLS. They are `UNSET`, `DISABLE`,
 
 </details>
 
-> :bulb: If you have not completed exercise 
-> [00-setup-introduction](00-setup-introduction.md) you **need** to label 
+> :bulb: If you have not completed exercise
+> [00-setup-introduction](00-setup-introduction.md) you **need** to label
 > your namespace with `istio-injection=enabled`.
 
 ## Exercise: Mutual TLS Inside the Mesh
 
-You will deploy all the services for the sentences application to observe 
-the affects of mTLS configuration. You will first observe that the default 
-mesh wide configuration will be inherited by your namespace. Afterwards you 
-will apply mTLS configuration to **your** namespace and observe the affects 
+You will deploy all the services for the sentences application to observe
+the affects of mTLS configuration. You will first observe that the default
+mesh wide configuration will be inherited by your namespace. Afterwards you
+will apply mTLS configuration to **your** namespace and observe the affects
 of STRICT and PERMISSIVE policies.
 
 ### PeerAuthentication
 
-The PeerAuthentication CRD is used to specify the mTLS settings for a workloads 
+The PeerAuthentication CRD is used to specify the mTLS settings for a workloads
 **requests**.
 
 An example of a peer authentication policy is seen below:
@@ -132,30 +132,30 @@ spec:
     mode: STRICT
 ```
 
-The above policy says to allow **both** plain-text and mTLS traffic for **all** 
-workloads in the `foo` namespace but **require** mTLS for the workload `myapp` 
+The above policy says to allow **both** plain-text and mTLS traffic for **all**
+workloads in the `foo` namespace but **require** mTLS for the workload `myapp`
 in the `foo` namespace.
 
 - The `namespace` definition scopes the policy to the defined namespace.
-If a policy is **not** namespace scoped it applies to **all** workloads 
+If a policy is **not** namespace scoped it applies to **all** workloads
 within the mesh.
 
-> There can be only one **mesh-wide** peer authentication policy, and only one 
-> **namespace-wide** peer authentication policy per namespace. If you configure 
+> There can be only one **mesh-wide** peer authentication policy, and only one
+> **namespace-wide** peer authentication policy per namespace. If you configure
 > more then Istio will **ignore the newer policies**.
 
 - The `selector` determines the workload to apply the PeerAuthentication to.
 
-> You can also specify the mTLS mode at the **port** level **if** you specify 
-a `selector`. 
+> You can also specify the mTLS mode at the **port** level **if** you specify
+a `selector`.
 
 ### DestinationRule
 
-The DestinationRule CRD is used to specify the TLS settings for upstream 
-connections. E.g. traffic the workload sends. These settings are common for 
-both HTTP and TCP connections. 
+The DestinationRule CRD is used to specify the TLS settings for upstream
+connections. E.g. traffic the workload sends. These settings are common for
+both HTTP and TCP connections.
 
-In a destination rule you use the `tls` keyword instead of the `mtls` keyword 
+In a destination rule you use the `tls` keyword instead of the `mtls` keyword
 under `spec.trafficPolicy`.
 
 ```yaml
@@ -173,8 +173,8 @@ spec:
       caCertificates: /etc/certs/rootcacerts.pem
 ```
 
-The modes are `DISABLE`, `SIMPLE`, `MUTUAL` and `ISTIO_MUTUAL`. For services 
-within the mesh `ISTIO_MUTUAL` is the natural choice as it uses Istio's 
+The modes are `DISABLE`, `SIMPLE`, `MUTUAL` and `ISTIO_MUTUAL`. For services
+within the mesh `ISTIO_MUTUAL` is the natural choice as it uses Istio's
 generated certs and they do not need to be specified in the destination rule.
 
 <details>
@@ -184,12 +184,12 @@ generated certs and they do not need to be specified in the destination rule.
 
 - `SIMPLE` - Originate a TLS connection to the upstream endpoint.
 
-- `MUTUAL` - Secure connections to the upstream using **mutual** TLS by 
+- `MUTUAL` - Secure connections to the upstream using **mutual** TLS by
 presenting client certificates for authentication.
 
 > You **must** specify the certificates when modes is set to MUTUAL.
 
-- `ISTIO_MUTUAL` - Same as MUTUAL except you do **not** specify the 
+- `ISTIO_MUTUAL` - Same as MUTUAL except you do **not** specify the
 client certificates as the certs generated for mTLS by Istio are used.
 
 </details>
@@ -200,7 +200,7 @@ A general overview of what you will be doing in the **Step By Step** section.
 
 - Deploy the sentences application services and see the effect of mesh wide mTLS config
 
-- Apply a STRICT and PERMISSIVE mTLS policy to **your** namespace and observe 
+- Apply a STRICT and PERMISSIVE mTLS policy to **your** namespace and observe
 the affects
 
 - Observe the affects on a service without a sidecar
@@ -219,18 +219,18 @@ Expand the **Tasks** section below to do the exercise.
 ___
 
 
-Run a for loop to substitute placeholders for environment variables and deploy 
-the services along with an ingress gateway and virtual service for routing 
+Run a for loop to substitute placeholders for environment variables and deploy
+the services along with an ingress gateway and virtual service for routing
 inbound traffic.
 
 ```console
 for file in 05-securing-with-mtls/start/*.yaml; do envsubst < $file | kubectl apply -f -; done
 ```
 
-Observe that the services are ready and we have a sidecar container per POD and 
+Observe that the services are ready and we have a sidecar container per POD and
 the sentences service is exposed with NodePort.
 
-> :bulb: We have also configured an entry point with a Gateway and VirtualService 
+> :bulb: We have also configured an entry point with a Gateway and VirtualService
 > but are also exposing it as a NodePort to demonstrate the effects of the policies.
 
 ```console
@@ -257,7 +257,7 @@ service/sentences   NodePort    172.20.92.234    <none>        5000:30962/TCP   
 ___
 
 
-Run the loop-query.sh script without parameters to reach the service over the 
+Run the loop-query.sh script without parameters to reach the service over the
 NodePort.
 
 ```console
@@ -268,18 +268,18 @@ NodePort.
 
 ___
 
-Go to Graph menu item and select the **Versioned app graph** from the drop 
-down menu. 
+Go to Graph menu item and select the **Versioned app graph** from the drop
+down menu.
 
-Check the display options as shown in the image below. Especially the **Security** 
-checkbox. 
+Check the display options as shown in the image below. Especially the **Security**
+checkbox.
 
-Notice the lock icons, which indicate whether the traffic is encrypted between 
+Notice the lock icons, which indicate whether the traffic is encrypted between
 the services.
 
-Select one of the **arrows** with a lock icon. You will be able to see on the 
-sidebar that the traffic is mTLS secured. Notice that traffic from the 
-`loop-query.sh` script(unknown) to the sentences frontend service is plain text 
+Select one of the **arrows** with a lock icon. You will be able to see on the
+sidebar that the traffic is mTLS secured. Notice that traffic from the
+`loop-query.sh` script(unknown) to the sentences frontend service is plain text
 HTTP traffic as we are using a NodePort to access it.
 
 ![Kiali default mTLS](images/kiali-mtls-default.png)
@@ -288,7 +288,7 @@ HTTP traffic as we are using a NodePort to access it.
 
 ___
 
-Create a file called `peer-authentication.yaml` in 
+Create a file called `peer-authentication.yaml` in
 `05-securing-with-mtls/start/`.
 
 Paste the following yaml into the file.
@@ -304,11 +304,11 @@ spec:
     mode: STRICT
 ```
 
-> :bulb: Note `$STUDENT_NS` in the above yaml. It is important that the 
-> PeerAuthentication CRD is scoped to **your individual** namespace. There can 
+> :bulb: Note `$STUDENT_NS` in the above yaml. It is important that the
+> PeerAuthentication CRD is scoped to **your individual** namespace. There can
 > only be one mesh wide and one namespace wide policy at a time.
 
-Substitute the placeholder with the value of the environment variable and apply 
+Substitute the placeholder with the value of the environment variable and apply
 the output with kubectl.
 
 ```console
@@ -324,11 +324,11 @@ Aramis (v2) is 35 years.
 curl: (56) Recv failure: Connection reset by peer
 ```
 
-You just applied a STRICT policy **requiring** all traffic to be over mTLS but 
-are accessing the frontend service directly over a NodePort and the traffic is 
+You just applied a STRICT policy **requiring** all traffic to be over mTLS but
+are accessing the frontend service directly over a NodePort and the traffic is
 plain-text over HTTP.
 
-Change the mode to `PERMISSIVE` in the `peer-authentication.yaml` file you just 
+Change the mode to `PERMISSIVE` in the `peer-authentication.yaml` file you just
 created.
 
 ```yaml
@@ -352,20 +352,20 @@ envsubst < 05-securing-with-mtls/start/peer-authentication.yaml | kubectl apply 
 
 ___
 
-Re-run the `loop-query.sh` script as before so we access the sentences frontend 
+Re-run the `loop-query.sh` script as before so we access the sentences frontend
 service over the NodePort as before.
 
 ```console
 ./scripts/loop-query.sh
 ```
 
-Go to Graph menu item and select the **Versioned app graph** from the drop 
-down menu. 
+Go to Graph menu item and select the **Versioned app graph** from the drop
+down menu.
 
-Check the display options as shown in the image below. Especially the 
-**Security** checkbox. 
+Check the display options as shown in the image below. Especially the
+**Security** checkbox.
 
-Notice that traffic is plain text HTTP traffic and is now allowed as 
+Notice that traffic is plain text HTTP traffic and is now allowed as
 `PERMISSIVE` mode allows both plain-text and mTLS.
 
 ![Kiali default mTLS](images/kiali-mtls-default.png)
@@ -387,23 +387,23 @@ loop-query.sh script with the option -g.
 
 ___
 
-Go to Graph menu item and select the **Versioned app graph** from the drop 
-down menu. 
+Go to Graph menu item and select the **Versioned app graph** from the drop
+down menu.
 
 Select the `istio-ingress` namespace along with your namespace and select the
 display checkboxes as shown below.
 
 ![Kiali with no sidecars](images/kiali-mtls-gw.png)
 
-We can now see that all the traffic within the mesh is mTLS. As the traffic is 
-now being routed through the ingress gateway it is being secured over mTLS by 
-the gateways standalone envoy proxy towards the sentences frontend service. 
+We can now see that all the traffic within the mesh is mTLS. As the traffic is
+now being routed through the ingress gateway it is being secured over mTLS by
+the gateways standalone envoy proxy towards the sentences frontend service.
 
-When `PERMISSIVE` mode is enabled both plain-text traffic and mTLS traffic are 
-allowed but mTLS **will be applied where possible**. 
+When `PERMISSIVE` mode is enabled both plain-text traffic and mTLS traffic are
+allowed but mTLS **will be applied where possible**.
 
-There is no real reason, besides for demonstration purposes, to expose the 
-sentences frontend service as a NodePort. Change the sentences service type to 
+There is no real reason, besides for demonstration purposes, to expose the
+sentences frontend service as a NodePort. Change the sentences service type to
 `ClusterIP` in the `sentences.yaml` file in `05-securing-with-mtls/start` folder.
 
 ```yaml
@@ -434,8 +434,8 @@ spec:
 
 ___
 
-As all of the traffic is now going through the ingress gateway you can apply 
-`STRICT` mode to your policy now. Change it in the `peer-authentication.yaml` 
+As all of the traffic is now going through the ingress gateway you can apply
+`STRICT` mode to your policy now. Change it in the `peer-authentication.yaml`
 file you created.
 
 Apply your changes.
@@ -444,8 +444,8 @@ Apply your changes.
 for file in 05-securing-with-mtls/start/*.yaml; do envsubst < $file | kubectl apply -f -; done
 ```
 
-> While migrating an application to full mTLS, it may be useful to start with 
-> a `PERMISSIVE` mTLS mode which allow a mix of mTLS and un-encrypted and 
+> While migrating an application to full mTLS, it may be useful to start with
+> a `PERMISSIVE` mTLS mode which allow a mix of mTLS and un-encrypted and
 > un-authenticated traffic.
 
 #### Task: Disable sidecar for the age service
@@ -454,7 +454,7 @@ ___
 
 What do you think will happen if a service has **no sidecar**?
 
-Modify the age service so it has no sidecar by adding an annotation to the file 
+Modify the age service so it has no sidecar by adding an annotation to the file
 `age.yaml` in `05-securing-with-mtls/start` folder to disable sidecar injection.
 
 The deployment section of the file should look like.
@@ -512,7 +512,7 @@ pod/age-v1-54fc4584d6-k94zk         1/1     Running       0          13s
 pod/age-v1-6d5946d477-f7fdp         2/2     Terminating   0          57m
 ```
 
-You really shouldn't see any interruptions from the `loop-query.sh` script 
+You really shouldn't see any interruptions from the `loop-query.sh` script
 running in the terminal.
 
 If a POD has no sidecar then the PeerAuthentication policy **cannot be applied**.
@@ -522,14 +522,14 @@ If a POD has no sidecar then the PeerAuthentication policy **cannot be applied**
 ___
 
 
-Go to Graph menu item and select the **Versioned app graph** from the drop 
-down menu. 
+Go to Graph menu item and select the **Versioned app graph** from the drop
+down menu.
 
 Select the `istio-ingress` namespace along with your namespace and select the
 display checkboxes as shown below.
 
-As the age service has no sidecar you will, **eventually**, not be able to see 
-traffic flowing to the age service in the graph even though it is still flowing 
+As the age service has no sidecar you will, **eventually**, not be able to see
+traffic flowing to the age service in the graph even though it is still flowing
 over HTTP.
 
 ![Kiali mTLS no age sidecar](images/kiali-mtls-no-age-service.png)
@@ -547,11 +547,11 @@ ___
 
 To show how we can control upstream mTLS settings with a DestinationRule, we
 create one that uses mTLS towards `v2` of the `name` service and no mTLS for
-`v1`. 
+`v1`.
 
 > :bulb: Note that we now need to use a `PERMISSIVE` Policy.
 
-Modify the `peer-authentication.yaml` in `05-securing-with-mtls/start/` 
+Modify the `peer-authentication.yaml` in `05-securing-with-mtls/start/`
 to use `PERMISSIVE` mode.
 
 ```yaml
@@ -565,7 +565,7 @@ spec:
     mode: PERMISSIVE
 ```
 
-Substitute the placeholder with the value of the environment variable and apply 
+Substitute the placeholder with the value of the environment variable and apply
 the output with kubectl.
 
 ```console
@@ -573,10 +573,10 @@ envsubst < 05-securing-with-mtls/start/peer-authentication.yaml | kubectl apply 
 ```
 
 Note, that a DestinationRule *will not* take effect until a route rule
-explicitly sends traffic to a subset. So you need both a virtual 
-service and a destination rule. 
+explicitly sends traffic to a subset. So you need both a virtual
+service and a destination rule.
 
-Create a file called `name-vs-dr.yaml` in `05-securing-with-mtls/start/` 
+Create a file called `name-vs-dr.yaml` in `05-securing-with-mtls/start/`
 directory.
 
 ```yaml
@@ -640,10 +640,10 @@ kubectl apply -f 05-securing-with-mtls/start/name-vs-dr.yaml
 ___
 
 
-Go to Graph menu item and select the **Versioned app graph** from the drop 
+Go to Graph menu item and select the **Versioned app graph** from the drop
 down menu. Select the checkboxes as shown in the below image.
 
-Now we see a missing padlock on the traffic towards `v1` of the name service. 
+Now we see a missing padlock on the traffic towards `v1` of the name service.
 (It might take a second to update, but if you select the connection,
 you may already be able to see the "percentage of mTLS" traffic decreasing.)
 
@@ -653,15 +653,15 @@ you may already be able to see the "percentage of mTLS" traffic decreasing.)
 
 ## Exercise: Mutual TLS From External Clients
 
-This exercise extends what we have done so far to demonstrate a common 
-use case of configuring mTLS with a service **external** to the mesh. A 
-service running in a different mesh for example. 
+This exercise extends what we have done so far to demonstrate a common
+use case of configuring mTLS with a service **external** to the mesh. A
+service running in a different mesh for example.
 
-In order to do this we will create a Certificate authority and certificates 
+In order to do this we will create a Certificate authority and certificates
 to enable strong workload identity.
 
-The TLS settings to control this will be defined in the 
-[Gateway](https://istio.io/latest/docs/reference/config/networking/gateway/#Gateway) 
+The TLS settings to control this will be defined in the
+[Gateway](https://istio.io/latest/docs/reference/config/networking/gateway/#Gateway)
 CRD.
 
 ```yaml
@@ -687,24 +687,24 @@ spec:
 
 ```
 
-- The port and tls blocks define the protocol and TLS mode to apply the 
-configuration to. In this exercise you will be using the `SIMPLE` and 
-the `MUTUAL` TLS modes. See this link for more information about 
+- The port and tls blocks define the protocol and TLS mode to apply the
+configuration to. In this exercise you will be using the `SIMPLE` and
+the `MUTUAL` TLS modes. See this link for more information about
 [Server TLS modes](https://istio.io/latest/docs/reference/config/networking/gateway/#ServerTLSSettings-TLSmode).
 
-- The credentialName represents a kubernetes secret containing the server side 
+- The credentialName represents a kubernetes secret containing the server side
 certificate.
 
-> :bulb: The secret **must** be in the **same** namespace as the ingress gateway 
-> controller. The gateway must be **namespaced** to be in the same namespace as 
-> the kubernetes secret. So **both** must be in the `istio-ingress` namespace in 
+> :bulb: The secret **must** be in the **same** namespace as the ingress gateway
+> controller. The gateway must be **namespaced** to be in the same namespace as
+> the kubernetes secret. So **both** must be in the `istio-ingress` namespace in
 > the above example and the gateway **must** be unique for this exercise.
 
 ### Overview
 
 A general overview of what you will be doing in the **Step By Step** section.
 
-- Generate needed certificate authority(CA) and certificates 
+- Generate needed certificate authority(CA) and certificates
 
 - Require `MUTUAL` TLS for port `443`
 
@@ -723,7 +723,7 @@ Expand the **Tasks** section below to do the exercise.
 
 ___
 
-Ensure that the gateway and virtual service for the `sentences` 
+Ensure that the gateway and virtual service for the `sentences`
 service from the first exercise is removed.
 
 ```console
@@ -741,10 +741,10 @@ Execute the `generate-certs.sh`script.
 ```console
 ./scripts/generate-certs.sh
 ```
-You should see namespace specific certs for both the server side and 
+You should see namespace specific certs for both the server side and
 client side in your workspace.
 
-There should also be a kubernetes secret in the `istio-ingress` namespace. 
+There should also be a kubernetes secret in the `istio-ingress` namespace.
 
 ```console
 kubectl get secrets -n istio-ingress
@@ -763,8 +763,8 @@ student1-sentences-tls-secret        Opaque    3      112m
 ___
 
 
-Modify the file `05-securing-with-mtls/start/sentences-ingress-gw.yaml` so 
-that it will be namespaced to the `istio-ingress` namespace and configure it 
+Modify the file `05-securing-with-mtls/start/sentences-ingress-gw.yaml` so
+that it will be namespaced to the `istio-ingress` namespace and configure it
 for `MUTUAL` TLS on port 443.
 
 ```yaml
@@ -794,7 +794,7 @@ spec:
 ___
 
 
-The gateway is now namespaced to the `istio-ingress` namespace so you need 
+The gateway is now namespaced to the `istio-ingress` namespace so you need
 to tell the virtual service which namespace the gateway is located in.
 
 Modify the file `05-securing-with-mtls/start/sentences-ingress-vs.yaml`.
@@ -820,7 +820,7 @@ spec:
 ___
 
 
-Once you have done the modifications to the gateway and virtual service, 
+Once you have done the modifications to the gateway and virtual service,
 substitute the placeholders with environment variable(s) and apply with kubectl.
 
 ```console
@@ -833,17 +833,17 @@ envsubst < 05-securing-with-mtls/start/sentences-ingress-vs.yaml | kubectl apply
 ___
 
 
-The `loop-query-mtls.sh` script uses the `client` certificates that were 
-generated for the mtls connection. 
+The `loop-query-mtls.sh` script uses the `client` certificates that were
+generated for the mtls connection.
 
 ```console
 scripts/loop-query-mtls.sh https+mtls
 ```
 
-Note the curl options printed when the script starts. The certificate 
+Note the curl options printed when the script starts. The certificate
 authority **and** the client cert, which is required for mTLS, are specified.
 
-It will look *something* like below but with the CA and client certs that can 
+It will look *something* like below but with the CA and client certs that can
 be found in your workspace as the below has been edited for simplicity.
 
 ```
@@ -863,9 +863,9 @@ ___
 scripts/loop-query-mtls.sh https
 ```
 
-**You should see an OpenSSL error**! Note the curl options printed when the 
-script starts. **Only** the **certificate authority** is passed as simple TLS 
-only requires server side authentication. But we have configured our gateway 
+**You should see an OpenSSL error**! Note the curl options printed when the
+script starts. **Only** the **certificate authority** is passed as simple TLS
+only requires server side authentication. But we have configured our gateway
 to use `MUTUAL` TLS. E.g.both client and server side authenticate.
 
 ```
@@ -881,10 +881,10 @@ Change the TLS mode to `SIMPLE` and apply the change.
 envsubst < 05-securing-with-mtls/start/sentences-ingress-gw.yaml | kubectl apply -f -
 ```
 
-Plain `https` will now work. 
+Plain `https` will now work.
 
-> You can still pass the `https+mtls` argument to the script and a connection 
-> will be made. Only server side authentication will be done. E.g. Istio will 
+> You can still pass the `https+mtls` argument to the script and a connection
+> will be made. Only server side authentication will be done. E.g. Istio will
 > simply **ignore** the client certs passed through the curl options.
 
 </details>
@@ -903,14 +903,14 @@ The main takeaways are:
 
 - Peer authentication policies only apply to workloads with a sidecar
 
-- Peer authentication policies apply to **all** the workloads within the 
+- Peer authentication policies apply to **all** the workloads within the
 mesh if **not** namespaced
 
 - The `STRICT` policy means strict and a `PERMISSIVE` policy is a good way to get started
 
 - Destination rules configure TLS for a workloads upstream traffic
 
-- When securing external traffic through ingress gateways you need to 
+- When securing external traffic through ingress gateways you need to
 consider namespaces in relation to kubernetes secrets and gateway controllers.
 
 ## Cleanup

--- a/07-istio-metrics-tour.md
+++ b/07-istio-metrics-tour.md
@@ -15,40 +15,40 @@ This exercise will demonstrate how to use metrics from Istio together with
 Prometheus. We will also see how application metrics and Istio metrics work
 together.
 
-> This exercise assumes an Istio deployment with `enablePrometheusMerge` 
+> This exercise assumes an Istio deployment with `enablePrometheusMerge`
 > enabled.
 
-Istio provides telemetry for all service communication within the mesh. 
-This telemetry provides **observability** of service behavior such as 
-overall traffic volume, error rates in traffic and response times. 
-All without any additional effort needed by the developer of a service. 
+Istio provides telemetry for all service communication within the mesh.
+This telemetry provides **observability** of service behavior such as
+overall traffic volume, error rates in traffic and response times.
+All without any additional effort needed by the developer of a service.
 
-One of the types of telemetry Istio generates is metrics. This is done 
-for **all** service traffic in the mesh. Both inbound and outbound. 
+One of the types of telemetry Istio generates is metrics. This is done
+for **all** service traffic in the mesh. Both inbound and outbound.
 
-Istio provides three levels of metrics. 
+Istio provides three levels of metrics.
 
-- Proxy-level: Standard metrics about all pass-through traffic along with 
+- Proxy-level: Standard metrics about all pass-through traffic along with
 detailed statistics about the administrative functions of the proxy itself.
 
-- Service-level: Service oriented metrics for monitoring the service 
+- Service-level: Service oriented metrics for monitoring the service
 communication.
 
 - Control-plane: A collection of self monitoring metrics.
 
-See the [documentation](https://istio.io/latest/docs/concepts/observability/#metrics) 
+See the [documentation](https://istio.io/latest/docs/concepts/observability/#metrics)
 for more details.
 
-> :bulb: If you have not completed exercise 
-> [00-setup-introduction](00-setup-introduction.md) you **need** to label 
+> :bulb: If you have not completed exercise
+> [00-setup-introduction](00-setup-introduction.md) you **need** to label
 > your namespace with `istio-injection=enabled`.
 
 ## Exercise
 
-First you will deploy the sentences service without sidecars and inspect 
-the metrics provided by application. Afterwards you will inject sidecars 
-and inspect the Istio metrics. Then you will enable a single scrape endpoint 
-for both the Istio and application metrics. Finally you view and query Istio 
+First you will deploy the sentences service without sidecars and inspect
+the metrics provided by application. Afterwards you will inject sidecars
+and inspect the Istio metrics. Then you will enable a single scrape endpoint
+for both the Istio and application metrics. Finally you view and query Istio
 metrics in Prometheus.
 
 ### Overview
@@ -145,7 +145,7 @@ This will return something like the following.
 sentence_requests_total{type="name"} 584.0
 ```
 
-This shows that the POD had received `584` requests from the 
+This shows that the POD had received `584` requests from the
 `loop-query.sh` script when we fetched metrics.
 
 Keep the terminal inside the test tool - we will use it again later.
@@ -155,10 +155,10 @@ Keep the terminal inside the test tool - we will use it again later.
 ___
 
 
-The deployed version of the sentences application have Istio sidecar injection 
+The deployed version of the sentences application have Istio sidecar injection
 **disabled**. This is done through annotations.
 
-You can investigate the yaml file `07-istio-metrics-tour/start/sentences.yaml` 
+You can investigate the yaml file `07-istio-metrics-tour/start/sentences.yaml`
 and observe the use of the `sidecar.istio.io/inject` annotation:
 
 ```yaml
@@ -173,7 +173,7 @@ Also note the Prometheus annotations that informs Prometheus, that this POD can
 be scraped for metrics on port `8000` and path `/metrics` - similar to what we
 just did manually.
 
-Re-deploy the sentences application without the annotation that disables 
+Re-deploy the sentences application without the annotation that disables
 sidecar injection.
 
 ```console
@@ -183,7 +183,7 @@ cat 07-istio-metrics-tour/start/age.yaml |grep -v inject | kubectl apply -f -
 ```
 
 If we run `kubectl get pods` now, we will see that we have two containers per
-POD. 
+POD.
 
 > :bulb: It may take a few seconds for the old PODs to terminate.
 > Wait for this before you continue.
@@ -231,7 +231,7 @@ cat 07-istio-metrics-tour/start/age.yaml |egrep -v 'inject|merge-metrics' | kube
 > :bulb: It may take a few seconds for the old PODs to terminate.
 > Wait for this before you continue.
 
-If we now inspect the POD annotations as above, we see the metrics scrape 
+If we now inspect the POD annotations as above, we see the metrics scrape
 endpoint has moved from the application to the sidecar.
 
 ```
@@ -245,8 +245,8 @@ Annotations:  prometheus.io/path: /stats/prometheus
 ___
 
 
-Now that we have a single merged scrape endpoint for the application metrics 
-and the Istio metrics we can fetch them both. 
+Now that we have a single merged scrape endpoint for the application metrics
+and the Istio metrics we can fetch them both.
 
 Re-run the `curl` command inside the test-tool as we did previously,
 but this time use the update scrape endpoint information:
@@ -255,8 +255,8 @@ but this time use the update scrape endpoint information:
 curl -s <POD IP>:15020/stats/prometheus | grep requests_total
 ```
 
-The result of which should look somewhat like the following for e.g. 
-the `name` service. 
+The result of which should look somewhat like the following for e.g.
+the `name` service.
 
 ```
 istio_requests_total{response_code="200",
@@ -270,9 +270,9 @@ sentence_requests_total{type="name"}                  265
 > Note the output above is edited for clarity.
 
 Note, that we both see a `sentence_requests_total` metric and an
-`istio_requests_total` metric - the former generated by the sentences 
-application and the other by the Istio sidecar. They should show the same 
-numeric value, however, since the Istio metric contains additional labels, 
+`istio_requests_total` metric - the former generated by the sentences
+application and the other by the Istio sidecar. They should show the same
+numeric value, however, since the Istio metric contains additional labels,
 e.g. source and destination of requests there could be differences
 with the request count spread out on differently labelled `istio_requests_total`
 metrics.
@@ -287,70 +287,70 @@ metrics.
 ___
 
 
-Istio makes the base monitoring data available but you still need something 
-to analyze and put the data to use. 
-[Prometheus](https://istio.io/latest/docs/ops/integrations/prometheus/) is 
-an open source monitoring system and time series database. You can use 
-Prometheus with Istio to record metrics that track the health of Istio and 
-of applications within the service mesh. 
+Istio makes the base monitoring data available but you still need something
+to analyze and put the data to use.
+[Prometheus](https://istio.io/latest/docs/ops/integrations/prometheus/) is
+an open source monitoring system and time series database. You can use
+Prometheus with Istio to record metrics that track the health of Istio and
+of applications within the service mesh.
 
 Browse to prometheus. The instructor should have given you the URL.
 
-Select the **graph** menu item on the top and enter `istio_requests_total` in 
-**Expression** box and hit execute. 
+Select the **graph** menu item on the top and enter `istio_requests_total` in
+**Expression** box and hit execute.
 
 You should see Istio metrics being returned as shown in the below image.
 
 ![Prometheus Istio Requests Total](images/prometheus-istio-requests-total.png)
 
-You can select the **graph** tab to see a graphical representation as shown 
+You can select the **graph** tab to see a graphical representation as shown
 below.
 
 ![Prometheus Istio Requests Total Graph](images/prometheus-istio-total-graph.png)
 
-The above results are for **all** traffic in the mesh, e.g. including traffic 
-going through the ingress gateway. 
+The above results are for **all** traffic in the mesh, e.g. including traffic
+going through the ingress gateway.
 
-If you want narrow the results down to the traffic between the sentences 
-services you could replace the expression with 
-`istio_requests_total{app="sentences"}`. This would give results for **all** 
+If you want narrow the results down to the traffic between the sentences
+services you could replace the expression with
+`istio_requests_total{app="sentences"}`. This would give results for **all**
 the services labelled with `app=sentences` across all namespaces.
 
-If you wanted the results for a specific service, say the `age` service, in a 
-specific namespace you could change the expression to use `destination_service` 
-and specify the full name with `<NAMESPACE>.svc.cluster.local`. 
+If you wanted the results for a specific service, say the `age` service, in a
+specific namespace you could change the expression to use `destination_service`
+and specify the full name with `<NAMESPACE>.svc.cluster.local`.
 
-For example to get istio requests total for the `age` service in the `student1` 
-namespace you could specify the expression 
+For example to get istio requests total for the `age` service in the `student1`
+namespace you could specify the expression
 `istio_requests_total{destination_service="age.student1.svc.cluster.local"}`
 
-Although not part of our course setup you can also visualize metrics using 
-[Grafana](https://istio.io/latest/docs/ops/integrations/grafana/) to create 
+Although not part of our course setup you can also visualize metrics using
+[Grafana](https://istio.io/latest/docs/ops/integrations/grafana/) to create
 Dashboards.
 
 </details>
 
 ## Summary
 
-In this exercise you have inspected some of the metrics Istio provides along 
+In this exercise you have inspected some of the metrics Istio provides along
 with how to enable for Prometheus.
 
 Important takeaways are:
 
-- Istio metrics begin with the sidecar. **Each** proxy generates metrics for 
+- Istio metrics begin with the sidecar. **Each** proxy generates metrics for
 **all** traffic passing through the sidecar proxy. Both inbound and outbound.
 
-- By **default** Istio enables only a small subset of envoy generated 
+- By **default** Istio enables only a small subset of envoy generated
 statistics to avoid overwhelming the metrics backend.
 
-- Istio provides three sets of metrics. Proxy-level metrics, service-level 
+- Istio provides three sets of metrics. Proxy-level metrics, service-level
 metrics and control plane metrics.
 
-- Istio has the ability to control scraping **entirely** by prometheus 
-annotations and this method is enabled by default. When enabled, appropriate 
-prometheus annotations will be added to all data plane pods. 
+- Istio has the ability to control scraping **entirely** by prometheus
+annotations and this method is enabled by default. When enabled, appropriate
+prometheus annotations will be added to all data plane pods.
 
-For an overview of the standard Istio **service-level** metrics see this 
+For an overview of the standard Istio **service-level** metrics see this
 [documentation](https://istio.io/latest/docs/reference/config/metrics/).
 
 ## Cleanup

--- a/08-distributed-tracing.md
+++ b/08-distributed-tracing.md
@@ -12,56 +12,56 @@
 
 ## Introduction
 
-This exercise will introduce some network delays and *slightly* more 
-complex deployment of the sentences application to **introduce** you to 
-another type of telemetry Istio generates. 
-[Distributed trace](https://istio.io/latest/docs/concepts/observability/#distributed-traces) 
-**spans**. 
+This exercise will introduce some network delays and *slightly* more
+complex deployment of the sentences application to **introduce** you to
+another type of telemetry Istio generates.
+[Distributed trace](https://istio.io/latest/docs/concepts/observability/#distributed-traces)
+**spans**.
 
-It will also introduce you to **one** of the distributed tracing backends 
+It will also introduce you to **one** of the distributed tracing backends
 Istio integrates with. [Jaeger](https://istio.io/latest/docs/ops/integrations/jaeger/).
 
-Istio supports distributed tracing through the envoy proxy sidecar. The proxies 
-**automatically** generate trace **spans** on **behalf** applications they proxy. 
-The sidecar proxy will send the tracing information directly to the tracing 
-backends. So the application developer does **not** know or worry about a 
-distributed tracing backend. 
+Istio supports distributed tracing through the envoy proxy sidecar. The proxies
+**automatically** generate trace **spans** on **behalf** applications they proxy.
+The sidecar proxy will send the tracing information directly to the tracing
+backends. So the application developer does **not** know or worry about a
+distributed tracing backend.
 
-However, Istio **does** rely on the application to propagate some headers for 
-subsequent outgoing requests so it can stitch together a complete view of the 
-traffic. See more **More Istio Distributed Tracing** below for a list of the 
+However, Istio **does** rely on the application to propagate some headers for
+subsequent outgoing requests so it can stitch together a complete view of the
+traffic. See more **More Istio Distributed Tracing** below for a list of the
 **required** headers.
 
 <details>
     <summary> More Istio Distributed Tracing </summary>
 
-Some forms of delays can be observed with the **metrics** that Istio tracks. 
+Some forms of delays can be observed with the **metrics** that Istio tracks.
 
-> Metrics are statistical and not specific to a certain request, i.e. we can 
-> only observe statistical data about observations like sums and averages. 
+> Metrics are statistical and not specific to a certain request, i.e. we can
+> only observe statistical data about observations like sums and averages.
 
-This is quite useful but fairly limited in a more complex service based 
-architecture. If the delay was caused by something more complicated it 
-could be difficult to diagnose purely from metrics due to their 
-statistical nature. For example the misbehaving application might not be 
-the immediate one from which you are observing a delay. In fact, it might 
+This is quite useful but fairly limited in a more complex service based
+architecture. If the delay was caused by something more complicated it
+could be difficult to diagnose purely from metrics due to their
+statistical nature. For example the misbehaving application might not be
+the immediate one from which you are observing a delay. In fact, it might
 be deep in the application tree.
 
-Distributed traces with spans provide a view of the life of a request as it 
+Distributed traces with spans provide a view of the life of a request as it
 travels across multiple hosts and services.
 
-> The “span” is the primary building block of a distributed trace, representing 
-> an individual unit of work done in a distributed system. Each component of the 
-> distributed system contributes a span - a named, timed operation representing 
+> The “span” is the primary building block of a distributed trace, representing
+> an individual unit of work done in a distributed system. Each component of the
+> distributed system contributes a span - a named, timed operation representing
 > a piece of the workflow.
-> 
-> Spans can (and generally do) contain “References” to other spans, which allows 
-> multiple Spans to be assembled into one complete Trace - a visualization of the 
+>
+> Spans can (and generally do) contain “References” to other spans, which allows
+> multiple Spans to be assembled into one complete Trace - a visualization of the
 > life of a request as it moves through a distributed system.
 
-In order for Istio to stitch together the spans and provide this view of the life 
-of a request. Istio Requires the following 
-[B3 trace headers](https://github.com/openzipkin/b3-propagation) to be propagated 
+In order for Istio to stitch together the spans and provide this view of the life
+of a request. Istio Requires the following
+[B3 trace headers](https://github.com/openzipkin/b3-propagation) to be propagated
 across the services.
 
 - x-request-id
@@ -74,18 +74,18 @@ across the services.
 
 </details>
 
-> :bulb: If you have not completed exercise 
-> [00-setup-introduction](00-setup-introduction.md) you **need** to label 
+> :bulb: If you have not completed exercise
+> [00-setup-introduction](00-setup-introduction.md) you **need** to label
 > your namespace with `istio-injection=enabled`.
 
 ## Exercise
 
-You are going to deploy a *slightly* more complex version of the sentences 
-application with a (simulated) bug that causes large delays on the combined 
-service. 
+You are going to deploy a *slightly* more complex version of the sentences
+application with a (simulated) bug that causes large delays on the combined
+service.
 
-Then you are going to see how Istio's distributed tracing telemetry is 
-leveraged by Kiali and Jaeger to help you identify where the delay is 
+Then you are going to see how Istio's distributed tracing telemetry is
+leveraged by Kiali and Jaeger to help you identify where the delay is
 happening.
 
 ### Overview
@@ -100,7 +100,7 @@ A general overview of what you will be doing in the **Step By Step** section.
 
 - Observe the distributed tracing telemetry in Jaeger
 
-- Route traffic through the ingress gateway 
+- Route traffic through the ingress gateway
 
 - Observe the distributed tracing telemetry in Jaeger
 
@@ -125,7 +125,7 @@ kubectl apply -f 08-distributed-tracing/start/
 ___
 
 
-In another shell, run the following to continuously query the sentence 
+In another shell, run the following to continuously query the sentence
 service through the **NodePort**.
 
 ```console
@@ -137,8 +137,8 @@ scripts/loop-query.sh
 ___
 
 
-Go to Graph menu item and select the **Versioned app graph** from the drop 
-down menu. 
+Go to Graph menu item and select the **Versioned app graph** from the drop
+down menu.
 
 If we select to display 'response time' we can see that traffic is flowing with relatively low delay on responses
 
@@ -159,8 +159,8 @@ kubectl apply -f 08-distributed-tracing/start/sentences-v2/
 ___
 
 
-Go to Graph menu item and select the **Versioned app graph** from the drop 
-down menu. 
+Go to Graph menu item and select the **Versioned app graph** from the drop
+down menu.
 
 If we select to display 'response time' we can see that there is a
 significant delay introduced by `v2` of the sentences
@@ -175,18 +175,18 @@ affecting both `v1` and `v2`:
 ___
 
 
-This is just a simulated bug and is easy to locate. But in a real world 
-scenario the bug may be introduced by interaction of a service deeper in the 
-application tree. To do a proper investigation you may need to trace the 
+This is just a simulated bug and is easy to locate. But in a real world
+scenario the bug may be introduced by interaction of a service deeper in the
+application tree. To do a proper investigation you may need to trace the
 traffic flow of the request through this tree.
 
-Kiali leverages Istio's distributed tracing telemetry and can be used to help 
+Kiali leverages Istio's distributed tracing telemetry and can be used to help
 in this type of scenario.
 
 Browse to **Workloads** on the left hand menu and select the `sentences-v2`
 workload. Then select the **Traces** tab.
 
-Here you can see that there are outlier **spans** well over 1 second. These 
+Here you can see that there are outlier **spans** well over 1 second. These
 are the spans generated by Istio.
 
 ![Kiali Traces](images/kiali-sentences-delay-traces.png)
@@ -195,17 +195,17 @@ Select one of the spans and Kiali will give you some trace details.
 
 ![Kiali Trace Details](images/kiali-trace-details.png)
 
-Select the **Span Details** tab and you can see the different spans generated 
-by the envoy proxy. Expanding the different entries will let you see details 
+Select the **Span Details** tab and you can see the different spans generated
+by the envoy proxy. Expanding the different entries will let you see details
 about where the request was sent and the response status.
 
 ![Kiali Span Details](images/kiali-span-details.png)
 
-> The colors on the span and trace details is controlled by Kiali so it 
-> is easier to see problems. The colors are based on an average of 
-> comparisons of each span duration vs the metrics for the same 
-> source/destination services. See this 
-> [blog](https://medium.com/kialiproject/trace-my-mesh-part-2-3-13cd6ccae1de) 
+> The colors on the span and trace details is controlled by Kiali so it
+> is easier to see problems. The colors are based on an average of
+> comparisons of each span duration vs the metrics for the same
+> source/destination services. See this
+> [blog](https://medium.com/kialiproject/trace-my-mesh-part-2-3-13cd6ccae1de)
 > for a more detailed dive into how Kiali does this.
 
 #### Task: Observe the distributed tracing telemetry in Jaeger
@@ -213,15 +213,15 @@ about where the request was sent and the response status.
 ___
 
 
-Jaeger also leverages Istio's distributed tracing and can also be used to 
-identify scenarios like this. 
+Jaeger also leverages Istio's distributed tracing and can also be used to
+identify scenarios like this.
 
-> It can be argued that Jaeger gives an easier to understand and more logical 
+> It can be argued that Jaeger gives an easier to understand and more logical
 > view of the traffic flow of a request.
 
 Browse to Jaeger and select the options as shown below and hit find traces.
 
-> :bulb: Select the sentences service corresponding to **your** namespace. 
+> :bulb: Select the sentences service corresponding to **your** namespace.
 > E.g `sentences.student1`, `sentences.student2`, etc.
 
 You should see a trace taking longer than 1 second in the graph and
@@ -231,7 +231,7 @@ the most resent traces).
 
 ![Search Traces In Jaeger](images/jaeger-delay-search.png)
 
-Select the trace, either from the graph or the list of traces. Then select 
+Select the trace, either from the graph or the list of traces. Then select
 the first entry in the flow and **expand** the **Tags** section.
 
 ![Jaeger Trace Details](images/jaeger-delay-details-initial.png)
@@ -243,8 +243,8 @@ bee seen as the root cause of the long delay.
 
 Next, select the first entry in the flow and **expand** the **Tags** section.
 
-From the details you can see that the envoy proxy provided the trace. You can 
-also see that the version of the sentences service is `v2`. 
+From the details you can see that the envoy proxy provided the trace. You can
+also see that the version of the sentences service is `v2`.
 
 ![Jaeger Trace Details](images/jaeger-delay-details.png)
 
@@ -253,15 +253,15 @@ also see that the version of the sentences service is `v2`.
 ___
 
 
-The traffic flow in our sentences application is pretty simple with low 
-complexity. But in much more complex system with a much more complicated 
-traffic flow and many more services, the ability of the envoy proxy to provide 
+The traffic flow in our sentences application is pretty simple with low
+complexity. But in much more complex system with a much more complicated
+traffic flow and many more services, the ability of the envoy proxy to provide
 traces without changes required at the application level is quite powerful.
 
-As an example you will create an IngressGateway and VirtualService to route 
+As an example you will create an IngressGateway and VirtualService to route
 external traffic through it to the sentences service.
 
-First create a file called `sentences-ingress-gw.yaml` in the directory 
+First create a file called `sentences-ingress-gw.yaml` in the directory
 `08-distributed-tracing/start/`.
 
 > :bulb: Edit the hosts field with **your** namespace. (With `envsubst` in the commands below.)
@@ -284,7 +284,7 @@ spec:
     - "$STUDENT_NS.sentences.$TRAINING_NAME.eficode.academy"
 ```
 
-Then create a file `sentences-ingress-vs.yaml` in the directory 
+Then create a file `sentences-ingress-vs.yaml` in the directory
 `08-distributed-tracing/start/`.
 
 ```yaml
@@ -315,15 +315,15 @@ envsubst < 08-distributed-tracing/start/sentences-ingress-vs.yaml | kubectl appl
 ___
 
 
-Now instead of hitting the NodePort of the sentences service use the 
-`./scripts/loop-query.sh` with the `-g` option and the entry point of 
+Now instead of hitting the NodePort of the sentences service use the
+`./scripts/loop-query.sh` with the `-g` option and the entry point of
 the gateway you just created.
 
 ```console
 ./scripts/loop-query.sh -g $STUDENT_NS.sentences.$TRAINING_NAME.eficode.academy
 ```
 
-Traffic will now be routed through the ingress gateway and towards the 
+Traffic will now be routed through the ingress gateway and towards the
 sentences service.
 
 #### Task: Observe the distributed tracing telemetry in Jaeger
@@ -334,11 +334,11 @@ ___
 Browse to Jaeger and select the options as shown below and hit find traces.
 
 You should be able to see the request flowing through the ingress gateway now.
-    
+
 > NB: it might take a minute or two for the traces to show up,
 > so don't get worried if you can't see them right away!
 >
-> :bulb: For demonstrating purposes, the Jaeger and Istio deployed during 
+> :bulb: For demonstrating purposes, the Jaeger and Istio deployed during
 > a training has been configured to collect **all** traces;
 > their default settings is to only keep between 0.1-1% of the traces.
 >
@@ -346,12 +346,12 @@ You should be able to see the request flowing through the ingress gateway now.
 > collecting everything would be infeasible, but the `loop-query`-script,
 > only sends a couple of requests each second.
 >
-> For practicalities: Storing everything means we won't have to "get lucky" (in terms of this exercise) 
+> For practicalities: Storing everything means we won't have to "get lucky" (in terms of this exercise)
 > when the system chooses which traces to keep or discard.
 
 ![Jaeger Ingress Search](images/jaeger-ingress-search.png)
 
-If you select one of the traces, either from the graph or the list of traces, 
+If you select one of the traces, either from the graph or the list of traces,
 you should be able to see the ingress gateway as part of the traffic flow details.
 
 ![Jaeger Ingress Details](images/jaeger-ingress-details.png)
@@ -360,21 +360,21 @@ you should be able to see the ingress gateway as part of the traffic flow detail
 
 ## Summary
 
-In this exercise you have seen how Istio's distributed tracing telemetry 
-can be leveraged to provide a less intrusive and more cohesive approach 
+In this exercise you have seen how Istio's distributed tracing telemetry
+can be leveraged to provide a less intrusive and more cohesive approach
 to distributed tracing.
 
 The main takeaways are:
 
 - Istio's envoy proxies generate the distributed trace spans for the services.
 
-- If a service has no proxy sidecar, distributed trace telemetry will not 
+- If a service has no proxy sidecar, distributed trace telemetry will not
 be generated.
 
-- Istio's envoy proxies provide the distributed trace telemetry to the 
+- Istio's envoy proxies provide the distributed trace telemetry to the
 supported backends integrated with the mesh.
 
-- The only requirement for the service is to propagate the **required** 
+- The only requirement for the service is to propagate the **required**
 B3 trace headers.
 
 ## Cleanup

--- a/README.md
+++ b/README.md
@@ -16,41 +16,41 @@ The natural order would be:
 - [A tour of Istio's metrics](07-istio-metrics-tour.md)
 - [Istio and distributed tracing](08-distributed-tracing.md)
 
-However each exercise **file** should be complete enough to allow you to 
+However each exercise **file** should be complete enough to allow you to
 do them in **your** preferred order.
 
-There is a corresponding (numbered) directory for each exercise file. The 
+There is a corresponding (numbered) directory for each exercise file. The
 kubernetes yaml will working with will be located here so you can view them.
 
-> :bulb: If you do **not** start with [Introducing the setup](00-setup-introduction.md) 
+> :bulb: If you do **not** start with [Introducing the setup](00-setup-introduction.md)
 > you will need to enable automatic sidecar injection prior to doing the exercise.
 
-Do note that there **can be multiple exercises** per exercise file. 
+Do note that there **can be multiple exercises** per exercise file.
 
 ## How to Read Exercise Files
 
-All exercise files start with an overall introduction followed by the actual 
-exercise(s). Each exercise will have a more detailed introduction to the 
+All exercise files start with an overall introduction followed by the actual
+exercise(s). Each exercise will have a more detailed introduction to the
 specific exercise.
 
 **Each exercise is summarized in bold text at the beginning.**
 
-A general overview is given first as a bulleted list to give you an 
-idea as to what you will be doing. 
+A general overview is given first as a bulleted list to give you an
+idea as to what you will be doing.
 
-This is followed by a detailed step-by-step set of **tasks** you execute 
-to complete the exercise. The tasks should be executed from a terminal in 
+This is followed by a detailed step-by-step set of **tasks** you execute
+to complete the exercise. The tasks should be executed from a terminal in
 the **root** directory, e.g. `istio-katas`.
 
-> :bulb: The actual tasks in the **Step by Step** section are **collapsed**. 
+> :bulb: The actual tasks in the **Step by Step** section are **collapsed**.
 > Select the arrow to **expand** the tasks section to do the exercise.
 
-The step-by-step instructions also explain _why_ some of the steps are 
+The step-by-step instructions also explain _why_ some of the steps are
 done in the way they are in the exercise.
 
-> Quoted blocks indicate points that are "nice to know" and can be safely 
-> ignored. They won't affect the outcome of the exercise, but generally 
+> Quoted blocks indicate points that are "nice to know" and can be safely
+> ignored. They won't affect the outcome of the exercise, but generally
 > include additional nuggets information.
 >
-> :bulb: If a quoted paragraph begins with a lightbulb, it indicates that 
+> :bulb: If a quoted paragraph begins with a lightbulb, it indicates that
 > it's a hint for the exercise step.

--- a/markdown-source/00-setup-introduction.mdpp
+++ b/markdown-source/00-setup-introduction.mdpp
@@ -422,7 +422,7 @@ has more features like the Istio Wizards feature which lets you create and
 delete istio configuration on the fly. It can do validation on the most common
 Istio objects and more.
 
-See the [documentation](https://kiali.io/documentation/latest/features/)
+See the [documentation](https://kiali.io/docs/features/)
 for a more complete overview.
 
 Main takeaways are:

--- a/markdown-source/00-setup-introduction.mdpp
+++ b/markdown-source/00-setup-introduction.mdpp
@@ -14,11 +14,11 @@
 This exercise introduces the sentences application which you will be using during the course.
 It also introduces you to the Kiali management console for the Istio service mesh.
 
-In the beginning of the exercise you will deploy the sentences application 
-and generate traffic between the services. But there will be no Envoy sidecars 
+In the beginning of the exercise you will deploy the sentences application
+and generate traffic between the services. But there will be no Envoy sidecars
 injected and Kiali will not be able to observe the traffic.
 
-Afterwards you will use a couple of different methods to enable sidecars. This 
+Afterwards you will use a couple of different methods to enable sidecars. This
 will allow Kiali to observe the traffic.
 
 <details>
@@ -42,12 +42,12 @@ The source code for the application can be seen in the  [sentences-app/](sentenc
 
 ### Kiali
 
-Kiali provides dashboards and observability by showing you the structure and 
-health of your service mesh. It provides detailed metrics, Grafana access and 
+Kiali provides dashboards and observability by showing you the structure and
+health of your service mesh. It provides detailed metrics, Grafana access and
 integrates with Jaeger for distributed tracing.
 
-One of it's most powerful features are it's graphs. They provide a powerful way 
-to visualize the topology of your service mesh. 
+One of it's most powerful features are it's graphs. They provide a powerful way
+to visualize the topology of your service mesh.
 
 It provides four main graph renderings of the mesh telemetry.
 
@@ -67,11 +67,11 @@ We are using Kiali to visualize the work done in this Istio course.
 
 ## Exercise: Get Familiar with Istio and Kiali.
 
-In this exercise, we are first deploying our application with vanilla 
-Kubernetes. We then visit the Kiali website to see that without a 
+In this exercise, we are first deploying our application with vanilla
+Kubernetes. We then visit the Kiali website to see that without a
 sidecar our service will not be included in istio.
 
-Then you will be using a few different techniques to enable Istio sidecars 
+Then you will be using a few different techniques to enable Istio sidecars
 and see the traffic flowing in Kiali.
 
 ### Overview
@@ -101,15 +101,15 @@ Expand the **Tasks** section below to do the exercise.
 
 ___
 
-You will need to know your namespace for later exercises. It is provided for 
-you in the environment variable `STUDENT_NS`. Check it with the following 
+You will need to know your namespace for later exercises. It is provided for
+you in the environment variable `STUDENT_NS`. Check it with the following
 command.
 
 ```console
 echo $STUDENT_NS
 ```
 
-Execute the following command and make sure it matches the value of the 
+Execute the following command and make sure it matches the value of the
 environment variable `STUDENT_NS`.
 
 ```console
@@ -178,16 +178,16 @@ Traffic is now flowing between the services. But that **doesn't** mean it is par
 ___
 
 
-Browse to **Applications** on the left hand menu. Click **Namespace** drop-down at the top left and 
+Browse to **Applications** on the left hand menu. Click **Namespace** drop-down at the top left and
 enter **your** namespace.
 
 Finally, select your `sentences` application from the center-part of the UI.
 
-You will see the application, workloads and services are discovered by Kiali. 
+You will see the application, workloads and services are discovered by Kiali.
 But not much else.
 
 The red icons beside the workloads mean we have no istio sidecars deployed.
-Browse the different tabs to see that there is no traffic nor metrics being captured. 
+Browse the different tabs to see that there is no traffic nor metrics being captured.
 As there are no sidecars the traffic is **not** part of the istio service mesh.
 
 ![Sentences with no sidecars](images/kiali-no-sidecars.png)
@@ -272,11 +272,11 @@ Browse to **Applications** on the left hand menu and select `sentences`.
 
 > Remember to filter by **your** namespace.
 
-Now you can see there are sidecars and the traffic is part of the mesh. 
+Now you can see there are sidecars and the traffic is part of the mesh.
 
 - Browse the different tabs to see the traffic and metrics being captured.
 
-> :bulb: It may take a minute before Kiali starts showing the traffic and 
+> :bulb: It may take a minute before Kiali starts showing the traffic and
 > metrics. You can change the refresh rate in the top right hand corner.
 
 ![Sentences with sidecars](images/kiali-with-sidecars.png)
@@ -287,7 +287,7 @@ Now you can see there are sidecars and the traffic is part of the mesh.
 ___
 
 
-Edit the file `00-setup-introduction/age.yaml` and add the annotation 
+Edit the file `00-setup-introduction/age.yaml` and add the annotation
 `sidecar.istio.io/inject: 'false'`.
 
 ```yaml
@@ -337,7 +337,7 @@ Use kubectl to see the number of pods running.
 kubectl get pods
 ```
 
-You should, eventually, see that the `age` service has only **one** pod. 
+You should, eventually, see that the `age` service has only **one** pod.
 E.g. it no longer has a sidecar and is **not** part of the service mesh.
 
 ```
@@ -350,9 +350,9 @@ sentences-v1-7cfbb658b6-rthxn   2/2     Running   0          8m41s
 If you re-inspect the application graph in Kiali, you will also
 notice, that the `age` service is no longer being shown.
 
-> Automatic sidecar injection provides a **pervasive** and homogenous approach 
-> to ensuring the features istio provides. For example telemetry like metrics 
-> and traces for observability. If you do not want a sidecar for a service, use 
+> Automatic sidecar injection provides a **pervasive** and homogenous approach
+> to ensuring the features istio provides. For example telemetry like metrics
+> and traces for observability. If you do not want a sidecar for a service, use
 > an **opt out** approach.
 
 #### Task: Inject sidecar for the `age` service
@@ -373,7 +373,7 @@ Use kubectl to see the number of pods running.
 kubectl get pods
 ```
 
-You should now see that the `age` service again has **two** pods. E.g. it has 
+You should now see that the `age` service again has **two** pods. E.g. it has
 a sidecar and is **again** part of the service mesh.
 
 ```
@@ -386,8 +386,8 @@ sentences-v1-7cfbb658b6-rthxn   2/2     Running   0          16m
 If you inspect the application graph in Kiali, you will see that the
 `age` service again is being shown.
 
-You didn't modify the static yaml with the above command. You simply took the 
-output of the cat command, piped it into grep which stripped out the annotation 
+You didn't modify the static yaml with the above command. You simply took the
+output of the cat command, piped it into grep which stripped out the annotation
 and applied the **output** with kubectl.
 
 #### Task: Investigate the different graphs
@@ -395,12 +395,12 @@ and applied the **output** with kubectl.
 ___
 
 
-Browse to the **graphs** and investigate the service, workload, app 
+Browse to the **graphs** and investigate the service, workload, app
 and versioned app graphs from the drop down at the top.
 
-> :bulb: Use the display options to modify what is shown in the 
+> :bulb: Use the display options to modify what is shown in the
 > different graphs. Showing request distribution is something
-> we will be using often. Also ensure you are running the 
+> we will be using often. Also ensure you are running the
 > `loop-query.sh` script to generate traffic.
 
 > :bulb: Use the `Legend` button to explain the different objects being shown.
@@ -411,33 +411,33 @@ and versioned app graphs from the drop down at the top.
 
 # Summary
 
-In this exercise you injected sidecars with automatic sidecar injection, 
-disabled sidecars with an annotation and manually injected a sidecar from 
-the command line.  Manually injecting sidecars or using annotations is not 
+In this exercise you injected sidecars with automatic sidecar injection,
+disabled sidecars with an annotation and manually injected a sidecar from
+the command line.  Manually injecting sidecars or using annotations is not
 a cohesive approach.
 
-You were also introduced to the sentences application and Kiali. There is not 
-enough time in the course to go into much more details around Kiali. But it 
-has more features like the Istio Wizards feature which lets you create and 
-delete istio configuration on the fly. It can do validation on the most common 
-Istio objects and more. 
+You were also introduced to the sentences application and Kiali. There is not
+enough time in the course to go into much more details around Kiali. But it
+has more features like the Istio Wizards feature which lets you create and
+delete istio configuration on the fly. It can do validation on the most common
+Istio objects and more.
 
-See the [documentation](https://kiali.io/documentation/latest/features/) 
+See the [documentation](https://kiali.io/documentation/latest/features/)
 for a more complete overview.
 
 Main takeaways are:
 
 * Annotations can be used to control sidecar injection.
 
-* Automatic sidecar injections is recommended. Automatic sidecar injection 
-ensures a more **pervasive** and homogenous approach for traffic management 
-and observability. It is less intrusive as it happens at the pod level and 
+* Automatic sidecar injections is recommended. Automatic sidecar injection
+ensures a more **pervasive** and homogenous approach for traffic management
+and observability. It is less intrusive as it happens at the pod level and
 you won't see any changes to the yaml itself.
 
-You can find more information about the different methods 
+You can find more information about the different methods
 [here](https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/).
 
-And you can find more details about sidecar configuration 
+And you can find more details about sidecar configuration
 [here](https://istio.io/latest/docs/concepts/traffic-management/#sidecars).
 
 # Cleanup

--- a/markdown-source/01-basic-traffic-routing.mdpp
+++ b/markdown-source/01-basic-traffic-routing.mdpp
@@ -10,31 +10,31 @@
 
 ## Introduction
 
-This exercise introduce you to the basics of traffic routing with Istio. 
-We are going to deploy all the services for our sentences application 
-and a new version `v2` of the **name** service. This will demonstrate normal 
-kubernetes load balancing between services. 
+This exercise introduce you to the basics of traffic routing with Istio.
+We are going to deploy all the services for our sentences application
+and a new version `v2` of the **name** service. This will demonstrate normal
+kubernetes load balancing between services.
 
 Then we are going to use two Istio custom resource definitions([CRD's](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)) which are
-the building blocks of Istio's traffic routing functionality to route traffic to 
+the building blocks of Istio's traffic routing functionality to route traffic to
 the desired workloads.
 
 These are the [VirtualService](https://istio.io/latest/docs/reference/config/networking/virtual-service/) and the [DestinationRule](https://istio.io/latest/docs/reference/config/networking/destination-rule/) CRD's.
 
-> :bulb: If you have not completed exercise 
-> [00-setup-introduction](00-setup-introduction.md) you **need** to label 
+> :bulb: If you have not completed exercise
+> [00-setup-introduction](00-setup-introduction.md) you **need** to label
 > your namespace with `istio-injection=enabled`.
 
 ### VirtualService
 
-You use virtual services to route traffic to kubernetes services. 
+You use virtual services to route traffic to kubernetes services.
 
 A VirtualService is used in addition to the normal Kubernetes service object.
-A VirtualService defines a set of traffic routing rules to apply when a host 
-is addressed. 
+A VirtualService defines a set of traffic routing rules to apply when a host
+is addressed.
 
-Each routing rule defines matching criteria for traffic of a 
-specific protocol. If the traffic is matched, then it is sent to a named 
+Each routing rule defines matching criteria for traffic of a
+specific protocol. If the traffic is matched, then it is sent to a named
 destination **service** or subset/version of it.
 
 > **Expand the example below for more details.**
@@ -62,42 +62,42 @@ spec:
         subset: v2
 ```
 
-- The **http** block is an [HTTPRoute](https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPRoute) 
-containing the routing rules for HTTP/1.1, HTTP/2 and gRPC traffic. 
+- The **http** block is an [HTTPRoute](https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPRoute)
+containing the routing rules for HTTP/1.1, HTTP/2 and gRPC traffic.
 
-> You can also use [TCPRoute](https://istio.io/latest/docs/reference/config/networking/virtual-service/#TCPRoute) 
-> and [TLSRoute](https://istio.io/latest/docs/reference/config/networking/virtual-service/#TLSRoute) 
+> You can also use [TCPRoute](https://istio.io/latest/docs/reference/config/networking/virtual-service/#TCPRoute)
+> and [TLSRoute](https://istio.io/latest/docs/reference/config/networking/virtual-service/#TLSRoute)
 > blocks for configuring routing.
 
-- The **hosts** field is the user addressable destination that the routing rules 
+- The **hosts** field is the user addressable destination that the routing rules
 apply to. It is the address used by a client when attempting to connect to a service.
-This is **virtual** and doesn't actually have to exist. For example 
-You could use it for consolidating routes to all services for an application. 
+This is **virtual** and doesn't actually have to exist. For example
+You could use it for consolidating routes to all services for an application.
 
-- The **destination** field specifies the **actual** destination of the routing 
-rule and **must** exist. In kubernetes this is a **service** and generally 
+- The **destination** field specifies the **actual** destination of the routing
+rule and **must** exist. In kubernetes this is a **service** and generally
 takes a form like `reviews`, `ratings`, etc.
 
-- The `mesh` field in the gateways block is a reserved keyword used to imply 
+- The `mesh` field in the gateways block is a reserved keyword used to imply
 **all** sidecars in the mesh.
 
-- The subset block is the name of a subset within the service and **must** be 
+- The subset block is the name of a subset within the service and **must** be
 defined in a **DestinationRule**.
 
 </details>
 
 ### DestinationRule
 
-Destination rules configure **what** happens to traffic for a destination 
+Destination rules configure **what** happens to traffic for a destination
 defined in a virtual service.
 
-You can think of virtual services as **how** you route your traffic to a given 
-destination, and then you use destination rules to configure **what** happens 
+You can think of virtual services as **how** you route your traffic to a given
+destination, and then you use destination rules to configure **what** happens
 to traffic for that destination.
 
 One of the most common uses of `DestinationRule` is to specify named service **subsets**.
 
-For example, grouping all of a service instances **versions**. You can then 
+For example, grouping all of a service instances **versions**. You can then
 use these **subsets** in a virtual service to control traffic to different versions.
 
 > **Expand the example below for more details.**
@@ -124,20 +124,20 @@ spec:
       version: v3
 ```
 
-> Destination rules are applied by Istio **after** virtual service routing 
+> Destination rules are applied by Istio **after** virtual service routing
 > rules are **evaluated**, so they apply to the traffic’s “real” destination.
 
-> :bulb: If you have not completed exercise 
-> [00-setup-introduction](00-setup-introduction.md) you **need** to label 
+> :bulb: If you have not completed exercise
+> [00-setup-introduction](00-setup-introduction.md) you **need** to label
 > your namespace with `istio-injection=enabled`.
 
 </details>
 
 ## Exercise: Routing To Specific Version
 
-We will look a bit into how a VirtualService and a DestinationRule can control 
-the flow of traffic in your namespace. We spin up two versions of the name 
-service in the namespace, and use the VirtualService and DestinationRule kinds 
+We will look a bit into how a VirtualService and a DestinationRule can control
+the flow of traffic in your namespace. We spin up two versions of the name
+service in the namespace, and use the VirtualService and DestinationRule kinds
 to control the traffic.
 
 ### Overview
@@ -152,10 +152,10 @@ A general overview of what you will be doing in the **Step By Step** section.
 
 - Use Kiali to observe the traffic flow
 
-- Create a VirtualService to route **all** traffic to the native k8's service 
+- Create a VirtualService to route **all** traffic to the native k8's service
 for name
 
-- Create a DestinationRule to send traffic to a specific version(workload) of 
+- Create a DestinationRule to send traffic to a specific version(workload) of
 the name service
 
 ### Step By Step
@@ -190,17 +190,17 @@ ___
 ___
 
 
-Go to Graph menu item and select the **Versioned app graph** from the drop 
+Go to Graph menu item and select the **Versioned app graph** from the drop
 down menu.
 
 ![50/50 split of traffic](images/kiali-blue-green-anno.png)
 
 What you are seeing here is kubernetes load balancing between PODS.
-Kubernetes, or more specifically the `kube-proxy`, will load balance in 
-either a *round robin* or *random* pattern depending on whether it is 
+Kubernetes, or more specifically the `kube-proxy`, will load balance in
+either a *round robin* or *random* pattern depending on whether it is
 running in *user space* proxy mode or *IP tables* proxy mode.
 
-You rarely want traffic routed to two version in an uncontrolled 
+You rarely want traffic routed to two version in an uncontrolled
 fashion.
 
 So why is this happening?
@@ -213,7 +213,7 @@ So why is this happening?
 ___
 
 
-Create a destination rule called `name-dr.yaml` in 
+Create a destination rule called `name-dr.yaml` in
 `01-basic-traffic-routing/start/` and apply it.
 
 ```yaml
@@ -233,16 +233,16 @@ spec:
     labels:
       version: v2
 ```
-The above destination rule says, when combined with a virtual service, **what** 
+The above destination rule says, when combined with a virtual service, **what**
 I want to do is send traffic to a workload **labeled** with either `v1` or `v2`.
 
 ```console
 kubectl apply -f 01-basic-traffic-routing/start/name-dr.yaml
 ```
-Applying the destination rule has no effect at this point because there is no 
+Applying the destination rule has no effect at this point because there is no
 virtual service including the destination rule.
 
-> :bulb: To avoid 503 errors **always** apply destination rules and changes to 
+> :bulb: To avoid 503 errors **always** apply destination rules and changes to
 > destination rules **prior** to changing virtual services.
 
 #### Task: Create a `VirtualService` to route ALL traffic to version 1 of the name service
@@ -250,7 +250,7 @@ virtual service including the destination rule.
 ___
 
 
-Create a virtual service called `name-vs.yaml` in 
+Create a virtual service called `name-vs.yaml` in
 `01-basic-traffic-routing/start/` and apply it.
 
 ```yaml
@@ -272,10 +272,10 @@ spec:
         subset: name-v1
 ```
 
-> The `host` field in the above yaml is the kubernetes short name for the service. 
-> Istio will translate the short name based one the **namespace** of the rule. 
-> E.g. if the virtual service is in namespace `default` the short name name will 
-> be interpreted as `name.default.svc.cluster.local`. What will happen if the 
+> The `host` field in the above yaml is the kubernetes short name for the service.
+> Istio will translate the short name based one the **namespace** of the rule.
+> E.g. if the virtual service is in namespace `default` the short name name will
+> be interpreted as `name.default.svc.cluster.local`. What will happen if the
 > **name** service is in the namespace `student1`?
 
 ```console
@@ -286,25 +286,25 @@ Immediately after applying this, you will see the output from the
 `loop-query.sh` change and strings with '(v2)' in them are no longer
 received.
 
-Go to **Graph** menu item in Kiali and select the **Versioned app graph** 
-from the drop down menu and observe the traffic flow. It may take a minute 
-before fully complete but you should see the traffic being routed to the 
+Go to **Graph** menu item in Kiali and select the **Versioned app graph**
+from the drop down menu and observe the traffic flow. It may take a minute
+before fully complete but you should see the traffic being routed to the
 `name-v1` **service**.
 
-> :bulb: Make sure to select `Idle Edges`, `Service Nodes` and 
+> :bulb: Make sure to select `Idle Edges`, `Service Nodes` and
 > `Virtual Services` in the Display drop down.
 
 ![Basic virtual service route](images/basic-route-vs.png)
 
-You can see in Kiali that the virtual service combined with the destination 
-rule subsets routes traffic to the name workload labeled `v1` even though the 
+You can see in Kiali that the virtual service combined with the destination
+rule subsets routes traffic to the name workload labeled `v1` even though the
 name service has no versions defined in the selector.
 
 #### Task: Add a route to version 2 of the name service as the **first** route
 
 ___
 
-Add a destination to the new service in the `name-vs.yaml` you 
+Add a destination to the new service in the `name-vs.yaml` you
 created before. But place it **before** the `name-v1` service and apply it.
 
 ```yaml
@@ -343,24 +343,24 @@ received.
 ___
 
 
-Go to **Graph** menu item in Kiali and select the **Versioned app graph** 
-from the drop down menu and observe the traffic flow. You will see that 
+Go to **Graph** menu item in Kiali and select the **Versioned app graph**
+from the drop down menu and observe the traffic flow. You will see that
 traffic is now being routed to the version 2 service.
 
 ![Routing precedence](images/basic-route-precedence-vs.png)
 
-Routing rules are evaluated in **sequential** order from top to bottom, with 
-the first rule in the virtual service definition being given highest priority. 
+Routing rules are evaluated in **sequential** order from top to bottom, with
+the first rule in the virtual service definition being given highest priority.
 
-Reorder the destination rules so that service `name-v1` will be evaluated 
+Reorder the destination rules so that service `name-v1` will be evaluated
 first and apply the changes.
 
 ```console
 kubectl apply -f 01-basic-traffic-routing/start/name-vs.yaml
 ```
 
-Go to **Graph** menu item in Kiali and select the **Versioned app graph** 
-from the drop down menu and observe the traffic flow.Traffic should once more 
+Go to **Graph** menu item in Kiali and select the **Versioned app graph**
+from the drop down menu and observe the traffic flow.Traffic should once more
 be routed to the `name-v1` service.
 
 ![Virtual service and destination rule](images/basic-route-vs.png)
@@ -369,37 +369,37 @@ be routed to the `name-v1` service.
 
 # Summary
 
-In this exercise you learned what a virtual service is and how to route traffic 
-to a destination service in kubernetes with an 
+In this exercise you learned what a virtual service is and how to route traffic
+to a destination service in kubernetes with an
 [HTTPRoute](https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPRoute).
 
 > Kubernetes only supports traffic distribution based on instance scaling. I.e. with the Kubernetes Service definition, we would need to scale the `name-v1` or `name-v2` Deployments to shift traffic.
 
-There is a lot more virtual services can do for traffic distribution like 
-match conditions for HTTPRoute on headers, uri, schemes, etc. HTTP redirects, 
+There is a lot more virtual services can do for traffic distribution like
+match conditions for HTTPRoute on headers, uri, schemes, etc. HTTP redirects,
 rewrites and more. We will looking at some of these in following exercises.
 
-See the [documentation](https://istio.io/latest/docs/reference/config/networking/virtual-service/#VirtualService) 
+See the [documentation](https://istio.io/latest/docs/reference/config/networking/virtual-service/#VirtualService)
 for more details.
 
-You also saw how a destination rule could be used to determine **what** 
-happens to traffic routed to a kubernetes service using labels identifying 
-workload versions. But you can also set **traffic policies** on a destination 
+You also saw how a destination rule could be used to determine **what**
+happens to traffic routed to a kubernetes service using labels identifying
+workload versions. But you can also set **traffic policies** on a destination
 rule to apply load balancing policies, connection pool settings, etc.
 
-See the [documentation](https://istio.io/latest/docs/reference/config/networking/destination-rule/#DestinationRule) 
+See the [documentation](https://istio.io/latest/docs/reference/config/networking/destination-rule/#DestinationRule)
 for more details.
 
 Main takeaways are:
 
-* A virtual services **hosts** field is a user addressable destination and can 
+* A virtual services **hosts** field is a user addressable destination and can
 be virtual.
 
-* A virtual services **destination** must exist exist. In Kubernetes this will 
+* A virtual services **destination** must exist exist. In Kubernetes this will
 be a Kubernetes Service.
 
-* A destination rule defines traffic policies that apply for the intended 
-service **after** routing has occurred with a virtual service. E.g. route 
+* A destination rule defines traffic policies that apply for the intended
+service **after** routing has occurred with a virtual service. E.g. route
 all traffic to v1, different load balancing modes for v1 and v2, etc.
 
 # Cleanup

--- a/markdown-source/01-basic-traffic-routing.mdpp
+++ b/markdown-source/01-basic-traffic-routing.mdpp
@@ -49,7 +49,7 @@ metadata:
   name: myservice-route
 spec:
   hosts:
-  - myservice               # Apply these rules for trafic to this host
+  - myservice               # Apply these rules for traffic to this host
   gateways:
   - mesh
   http:
@@ -395,7 +395,7 @@ Main takeaways are:
 * A virtual services **hosts** field is a user addressable destination and can
 be virtual.
 
-* A virtual services **destination** must exist exist. In Kubernetes this will
+* A virtual services **destination** must exist. In Kubernetes this will
 be a Kubernetes Service.
 
 * A destination rule defines traffic policies that apply for the intended

--- a/markdown-source/01-basic-traffic-routing.mdpp
+++ b/markdown-source/01-basic-traffic-routing.mdpp
@@ -55,11 +55,8 @@ spec:
   http:
   - route:
     - destination:
-        host: myservice     # Send to this Kubernetes Service
-        subset: v1          # but only this subset of the Service
-    - destination:
-        host: myservice
-        subset: v2
+        host: myservice     # Send to this Kubernetes Deployment
+        subset: v1          # but only this subset of the Deployment
 ```
 
 - The **http** block is an [HTTPRoute](https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPRoute)
@@ -77,6 +74,9 @@ You could use it for consolidating routes to all services for an application.
 - The **destination** field specifies the **actual** destination of the routing
 rule and **must** exist. In kubernetes this is a **service** and generally
 takes a form like `reviews`, `ratings`, etc.
+
+- The **weight** field can be used to specify the distribution of traffic,
+    Within a single route.
 
 - The `mesh` field in the gateways block is a reserved keyword used to imply
 **all** sidecars in the mesh.
@@ -115,7 +115,7 @@ spec:
   subsets:
   - name: v1           # Define a named subset 'v1'
     labels:
-      version: v1      # Labels on 'host', e.g. labels on the Kubernetes Service
+      version: v1      # Labels on 'host', e.g. labels on the Kubernetes Deployment
   - name: v2
     labels:
       version: v2

--- a/markdown-source/02-deployment-patterns.mdpp
+++ b/markdown-source/02-deployment-patterns.mdpp
@@ -252,7 +252,7 @@ route was used.
 ___
 
 
-In the `name-vs-yaml` file remove the default route and apply the changes.
+In the `name-vs.yaml` file remove the default route and apply the changes.
 
 ```yaml
 apiVersion: networking.istio.io/v1beta1
@@ -358,7 +358,8 @@ services in the application tree.
 
 As the header is **not** propagated to the name service the default route is hit.
 > You would need to modify the sentence service to propagate the header onwards
-> so the virtual service could match on it.
+> so the virtual service could match on it. If you look in the code for the
+> application, you can see which headers are currently forwarded.
 
 ![Bad Header](images/kiali-bad-header.png)
 
@@ -418,9 +419,15 @@ In the above example we define a traffic distribution percentage with
 the `weight` fields on the destinations of the HTTPRoute. The `v1`
 workload of `my-service` destination will receive 90% of **all**
 traffic while the `v2` workload of `my-service` will receive 10% of
-**all** traffic.  The `weight` field is not percentages and
-distribution is relative to the sum of weights, which may be different
-from 100.
+**all** traffic.
+
+> NB: Before `v1.13` of Istio, `weight` were thought to be percentages,
+> and the sum of the `weight` fields across the
+> destinations of a single route `SHOULD BE == 100`.
+>
+> With Istio `v1.13` weights specify relative proportions, and
+> distribution is relative to the sum of weights, which may be different
+> from 100. A destination will receive `weight/(sum of all weights)` requests.
 
 ### Overview
 
@@ -517,6 +524,9 @@ spec:
 
 > Again, notice the indentation. `name-v3` will only be hit if the header
 > match is true. The other two routes are evaluated top down.
+
+> ❗ If you just did the blue/green exercise,
+> make sure your routes to `name-v1` and `name-v2` are like above.
 
 ```console
 kubectl apply -f 02-deployment-patterns/start/name-vs.yaml
@@ -636,7 +646,7 @@ percentage of the **overall** traffic change to look more like the 90/10 weight.
 ___
 
 
-Stop sending traffic to `v3` with `./scripts/loop-query.sh.
+Stop sending traffic to `v3` with `./scripts/loop-query.sh -h 'x-test: use-v3'`.
 
 Remove the `name-v1` subset from `name-dr.yaml` file.
 
@@ -698,6 +708,16 @@ kubectl apply -f 02-deployment-patterns/start/name-vs.yaml
 > :bulb: You could simply adjust the weight values in the
 > `name-vs.yaml` file. But for the next exercise it will cause
 > less confusion if the subsets and destinations are removed.
+
+> NB: do note that in the above we're removing a subset from the DestinationRule,
+> and changing the VirtualService, but we're applying the DestinationRule first.
+> This means that theoretically the old VirtualService could be routing to a subset
+> that doesn't exist, and drop traffic. This isn't an issue during our exercises.
+>
+> But in "real life" when you're removing subsets, you want to update your VirtualServices first,
+> since you don't want to use a subset that's going to disappear.
+> And when you're adding subsets, you want to update the DestinationRules first,
+> because we want the subsets to be there, before we're updating our VirtualServices.
 
 Finally, delete the `name-v1` workload.
 
@@ -985,6 +1005,8 @@ The main takeaways are:
 * Istio enables you to apply various deployment patterns inside the mesh
 
 * The match field is quite powerful
+
+* The order in which you update DestinationRules and VirtualServices is important
 
 * You should always provide a default route when using a match
 

--- a/markdown-source/02-deployment-patterns.mdpp
+++ b/markdown-source/02-deployment-patterns.mdpp
@@ -11,22 +11,22 @@
 - Mirror traffic for shadow deployment
 
 ## Introduction
-These exercises will introduce you to the match, weight and mirror fields of the 
-HTTPRoute. These fields and their combinations can be used to enable several 
-useful deployment patterns like blue/green deployments, canary deployments and 
+These exercises will introduce you to the match, weight and mirror fields of the
+HTTPRoute. These fields and their combinations can be used to enable several
+useful deployment patterns like blue/green deployments, canary deployments and
 shadow deployments.
 
 These exercises build on the [Basic traffic routing](01-basic-traffic-routing.md) exercises.
 
-> :bulb: If you have not completed exercise 
-> [00-setup-introduction](00-setup-introduction.md) you **need** to label 
+> :bulb: If you have not completed exercise
+> [00-setup-introduction](00-setup-introduction.md) you **need** to label
 > your namespace with `istio-injection=enabled`.
 
-## Exercise: Blue/Green Deployment 
+## Exercise: Blue/Green Deployment
 
-This exercise is going to introduce you to the HTTPRoute `match` field in a 
-virtual service. We want to implement a blue/green deployment pattern which 
-allows the **client** to actively select a version of the **name** service 
+This exercise is going to introduce you to the HTTPRoute `match` field in a
+virtual service. We want to implement a blue/green deployment pattern which
+allows the **client** to actively select a version of the **name** service
 it will hit.
 
 ```yaml
@@ -48,11 +48,11 @@ spec:
             subset: v2
 ```
 
-In the **example** above we define a HTTPMatchRequest with the field `match`. 
-The `headers` field declares that we want to match on **request** headers. 
+In the **example** above we define a HTTPMatchRequest with the field `match`.
+The `headers` field declares that we want to match on **request** headers.
 The `exact` field declares that the header **must** match exactly `use-v2`.
 
-Istio allows to use other parts of **incoming** requests and match them to values 
+Istio allows to use other parts of **incoming** requests and match them to values
 **you** define. To see what these are expand **More Info** below.
 
 <details>
@@ -81,15 +81,15 @@ headers is used uri, schema, method and authority are ignored.
 
 - **regex:** The **provided** value will be matched based on the regex
 
-**NOTE:** Istio regex's use the [re2](https://github.com/google/re2/wiki/Syntax) 
+**NOTE:** Istio regex's use the [re2](https://github.com/google/re2/wiki/Syntax)
 regular expression syntax
 
 </details>
 
-You can have multiple conditions in a match block and multiple match blocks. 
+You can have multiple conditions in a match block and multiple match blocks.
 
-> :bulb: All conditions inside a **single** match block have **AND** semantics, 
-> while the list of **match blocks** have **OR** semantics. The rule is matched 
+> :bulb: All conditions inside a **single** match block have **AND** semantics,
+> while the list of **match blocks** have **OR** semantics. The rule is matched
 > if any one of the match blocks succeed.
 
 **NOTE:** Matches are evaluated **prior** to any destination's being applied.
@@ -104,7 +104,7 @@ A general overview of what you will be doing in the **Step By Step** section.
 
 - Observe the traffic flow with Kiali
 
-- Route traffic to a specific version `v2` matching a header specified by the 
+- Route traffic to a specific version `v2` matching a header specified by the
 client
 
 ### Step by Step
@@ -125,7 +125,7 @@ kubectl apply -f 02-deployment-patterns/start/name-v1/
 kubectl apply -f 02-deployment-patterns/start/name-v2/
 ```
 
-This will deploy two versions of the **name** service along with a destination 
+This will deploy two versions of the **name** service along with a destination
 rule and virtual service as defined in a previous exercise.
 
 #### Task: Run the `scripts/loop-query.sh` script
@@ -142,10 +142,10 @@ ___
 ___
 
 
-In Kiali go to **graphs**, select **your** namespace and the 
+In Kiali go to **graphs**, select **your** namespace and the
 **versioned app graph**.
 
-You should see the traffic being routed to the `name-v1` workload because of 
+You should see the traffic being routed to the `name-v1` workload because of
 the precedence of the routes in the name virtual service.
 
 ![Precedence routing](images/kiali-precedence-routing.png)
@@ -162,8 +162,8 @@ Use `ctrl`+ `c` to stop the `loop-query.sh` script.
 ___
 
 
-Update the `name-vs.yaml` file with an 
-[HTTPMatchRequest](https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPMatchRequest) 
+Update the `name-vs.yaml` file with an
+[HTTPMatchRequest](https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPMatchRequest)
 and apply it.
 
 ```yaml
@@ -212,7 +212,7 @@ ___
 
 
 You should see all traffic being directed to `v2` of the name workload.
-That is because the match evaluated to true and the route **under** the 
+That is because the match evaluated to true and the route **under** the
 match block is used.
 
 ![Header based routing](images/kiali-blue-green.png)
@@ -222,7 +222,7 @@ match block is used.
 ___
 
 
-Use `ctrl`+ `c` to stop the `loop-query.sh` script and run it without passing 
+Use `ctrl`+ `c` to stop the `loop-query.sh` script and run it without passing
 the header.
 
 ```console
@@ -234,17 +234,17 @@ the header.
 ___
 
 
-You should now see all traffic being routed to `v1` of the name workload. 
-This is because when the match did **not** evaluate to true the default 
-route was used. 
+You should now see all traffic being routed to `v1` of the name workload.
+This is because when the match did **not** evaluate to true the default
+route was used.
 
-> Whenever you use matches for traffic routing. You should **always** ensure you 
+> Whenever you use matches for traffic routing. You should **always** ensure you
 > have a **default** route.
 
 ![Default route](images/kiali-default-destination.png)
 
-> :bulb: In the file `name-vs.yaml` you created. Notice the indentation for the 
-> route to `name-v1`, which is our **default** route. E.g the route to `name-v2` 
+> :bulb: In the file `name-vs.yaml` you created. Notice the indentation for the
+> route to `name-v1`, which is our **default** route. E.g the route to `name-v2`
 > is nested **under** the `match` block. That is a different route...
 
 #### Task: Remove the default route
@@ -286,12 +286,12 @@ kubectl apply -f 02-deployment-patterns/start/name-vs.yaml
 ___
 
 
-Go to Graph menu item and select the **Versioned app graph** from the drop 
+Go to Graph menu item and select the **Versioned app graph** from the drop
 down menu.
 
-The problem we have here is that the match is evaluated first **before** any 
-destination's are applied. Since the match was not true the route defined under 
-it was not applied. Nor have we provided another route to fall back on when the 
+The problem we have here is that the match is evaluated first **before** any
+destination's are applied. Since the match was not true the route defined under
+it was not applied. Nor have we provided another route to fall back on when the
 match does not evaluate to true.
 
 ![Missing default destination](images/kiali-no-default-destination.png)
@@ -334,11 +334,11 @@ spec:
 kubectl apply -f 02-deployment-patterns/start/name-vs.yaml
 ```
 
-Now try using a different header with the value `use-v2`. Modify the virtual 
-service to reflect the header you chose and pass the header to the 
+Now try using a different header with the value `use-v2`. Modify the virtual
+service to reflect the header you chose and pass the header to the
 loop-query.sh script.
 
-> You can call it anything you want. For example `x-version` is used 
+> You can call it anything you want. For example `x-version` is used
 > below but it really doesn't matter.
 
 ```console
@@ -350,14 +350,14 @@ loop-query.sh script.
 ___
 
 
-Go to Graph menu item and select the **Versioned app graph** from the drop 
+Go to Graph menu item and select the **Versioned app graph** from the drop
 down menu.
 
-In order for a match on a header to work it **must** be propagated to all the 
-services in the application tree. 
+In order for a match on a header to work it **must** be propagated to all the
+services in the application tree.
 
-As the header is **not** propagated to the name service the default route is hit. 
-> You would need to modify the sentence service to propagate the header onwards 
+As the header is **not** propagated to the name service the default route is hit.
+> You would need to modify the sentence service to propagate the header onwards
 > so the virtual service could match on it.
 
 ![Bad Header](images/kiali-bad-header.png)
@@ -366,32 +366,32 @@ As the header is **not** propagated to the name service the default route is hit
 
 ## Exercise: Canary Deployment
 
-This exercise is going to introduce you to the HTTPRoute `weight` field in a 
-virtual service. We want to implement a canary deployment pattern to the 
-**name** service's `v1` and `v2` workloads and **header** based blue/green 
+This exercise is going to introduce you to the HTTPRoute `weight` field in a
+virtual service. We want to implement a canary deployment pattern to the
+**name** service's `v1` and `v2` workloads and **header** based blue/green
 deployment to a `v3` workload.
 
 <details>
     <summary> More Info </summary>
 
-The canary deployment pattern is often employed **after** a blue/green deployment 
-pattern. Blue/green deployments are characterized by an **explicit** 
-choice by the **client/user** of which version to use. 
+The canary deployment pattern is often employed **after** a blue/green deployment
+pattern. Blue/green deployments are characterized by an **explicit**
+choice by the **client/user** of which version to use.
 
-A canary deployment removes the need for this explicit choice by **weighting** 
-the traffic between **releases**. But it is not an uncommon scenario to have a 
-canary deployment alongside of a blue/green deployment for the next 
+A canary deployment removes the need for this explicit choice by **weighting**
+the traffic between **releases**. But it is not an uncommon scenario to have a
+canary deployment alongside of a blue/green deployment for the next
 **unreleased** version.
 
 </details>
 
-Canary deployment is a pattern for rolling out **releases** to a **subset** 
-of users/clients. The idea is to test and gather feedback from this subset and 
+Canary deployment is a pattern for rolling out **releases** to a **subset**
+of users/clients. The idea is to test and gather feedback from this subset and
 reduce risk by gradually introducing a new release.
 
-> :laughing: Fun fact. The term canary comes from the coal mining industry 
-> where canaries were used to alert miners when toxic gases reached dangerous 
-> levels. In the same way canary deployments can alert you to issues, bad 
+> :laughing: Fun fact. The term canary comes from the coal mining industry
+> where canaries were used to alert miners when toxic gases reached dangerous
+> levels. In the same way canary deployments can alert you to issues, bad
 > design or whether features actually give the intended value.
 
 ```yaml
@@ -432,15 +432,15 @@ A general overview of what you will be doing in the **Step By Step** section.
 
 - Observe the traffic flow with Kiali
 
-- incorporate version `v3` of the name service in the destination rule and 
+- incorporate version `v3` of the name service in the destination rule and
 the virtual service for header based routing
 
 > The use case is that new version `v3` will be the new blue/green deployment.
 
-- Create a canary deployment for version `v1`and `v2` of the name service with 
+- Create a canary deployment for version `v1`and `v2` of the name service with
 the `weight` field
 
-> The use case is that `v2` has been validated and you are doing a canary 
+> The use case is that `v2` has been validated and you are doing a canary
 deployment to reduce risk.
 
 - Promote `v2` of the name service to receive **all** traffic.
@@ -515,7 +515,7 @@ spec:
         subset: name-v2
 ```
 
-> Again, notice the indentation. `name-v3` will only be hit if the header 
+> Again, notice the indentation. `name-v3` will only be hit if the header
 > match is true. The other two routes are evaluated top down.
 
 ```console
@@ -537,11 +537,11 @@ If not already running, execute the `loop-query.sh` script.
 ___
 
 
-Go to Graph menu item and select the **Versioned app graph** from the drop 
+Go to Graph menu item and select the **Versioned app graph** from the drop
 down menu.
 
-The traffic should still be routed to the `v1` workload as the match condition 
-did not evaluate to true and order of precedence dictates the first destination 
+The traffic should still be routed to the `v1` workload as the match condition
+did not evaluate to true and order of precedence dictates the first destination
 which will direct traffic to `v1` workload.
 
 ![Precedence routing](images/kiali-bad-header.png)
@@ -583,7 +583,7 @@ spec:
       weight: 10                # and this
 ```
 
-> :bulb: The weight is distributed by **route** so the destination for `v2` must 
+> :bulb: The weight is distributed by **route** so the destination for `v2` must
 > be under the same route block.
 
 ```console
@@ -595,10 +595,10 @@ kubectl apply -f 02-deployment-patterns/start/name-vs.yaml
 ___
 
 
-Go to Graph menu item and select the **Versioned app graph** from the drop 
+Go to Graph menu item and select the **Versioned app graph** from the drop
 down menu.
 
-You should see that the traffic is distributed approximately 90% to `v1` and 10% 
+You should see that the traffic is distributed approximately 90% to `v1` and 10%
 to `v2`.
 
 ![90/10 traffic distribution](images/kiali-canary-anno.png)
@@ -619,14 +619,14 @@ ___
 
 You can see that the traffic distribution is no longer 90/10 between `v1` and `v2`.
 
-We have two clients. One has **all** traffic routed `v3`. The others traffic is 
+We have two clients. One has **all** traffic routed `v3`. The others traffic is
 distributed 90% to `v1` and 10% `v2`.
 
-The Kiali graph is showing you the percentage of the **overall** traffic. The 
+The Kiali graph is showing you the percentage of the **overall** traffic. The
 weight is applied to the traffic that hits the second route.
 
-Run `scripts/loop-query.sh` **without** the header in another terminal, or 
-several, and observe how it affects the traffic distribution. You will see the 
+Run `scripts/loop-query.sh` **without** the header in another terminal, or
+several, and observe how it affects the traffic distribution. You will see the
 percentage of the **overall** traffic change to look more like the 90/10 weight.
 
 ![90/10 distribution with Blue green](images/kiali-canary-blue-green.png)
@@ -658,7 +658,7 @@ spec:
       version: v3
 ```
 
-Remove the `name-v1` destination from `name-vs.yaml` file, adjust 
+Remove the `name-v1` destination from `name-vs.yaml` file, adjust
 the weight field to 100% on `name-v2` destination and apply changes.
 
 ```yaml
@@ -695,11 +695,11 @@ kubectl apply -f 02-deployment-patterns/start/name-vs.yaml
 
 ```
 
-> :bulb: You could simply adjust the weight values in the 
-> `name-vs.yaml` file. But for the next exercise it will cause 
+> :bulb: You could simply adjust the weight values in the
+> `name-vs.yaml` file. But for the next exercise it will cause
 > less confusion if the subsets and destinations are removed.
 
-Finally, delete the `name-v1` workload. 
+Finally, delete the `name-v1` workload.
 
 ```console
 kubectl delete -f 02-deployment-patterns/start/name-v1/
@@ -710,7 +710,7 @@ kubectl delete -f 02-deployment-patterns/start/name-v1/
 ___
 
 
-All traffic will now be routed to the `v2` workload. Normally you would adjust 
+All traffic will now be routed to the `v2` workload. Normally you would adjust
 the weights gradually to expose `v2` to more and more users.
 
 ![Canary Promoted](images/kiali-canary-promoted.png)
@@ -719,34 +719,34 @@ the weights gradually to expose `v2` to more and more users.
 
 ## Exercise: Shadow Deployment
 
-This exercise will introduce you to the HTTPRoute `mirror` field in a virtual 
-service. We want to route traffic to the **name** service `v3` workload while 
-still forwarding traffic to the original destination. This is often called a 
+This exercise will introduce you to the HTTPRoute `mirror` field in a virtual
+service. We want to route traffic to the **name** service `v3` workload while
+still forwarding traffic to the original destination. This is often called a
 shadow deployment.
 
-> In Istio mirrored traffic is on a best effort basis. This means that the 
-> sidecar/gateway will **not** wait for mirrored traffic **before** sending 
+> In Istio mirrored traffic is on a best effort basis. This means that the
+> sidecar/gateway will **not** wait for mirrored traffic **before** sending
 > a response from the original destination.
 
-The use case here is the following. You have **completed** a canary deployment 
-for `v1` and `v2` of the **name** service. You have also done a blue/green 
-deployment for `v3` of the **name** service. You have tested it's functionality 
-and everything looks good. Now you would like to load test `v3` as it has some 
+The use case here is the following. You have **completed** a canary deployment
+for `v1` and `v2` of the **name** service. You have also done a blue/green
+deployment for `v3` of the **name** service. You have tested it's functionality
+and everything looks good. Now you would like to load test `v3` as it has some
 changes that could affect performance.
 
 <details>
     <summary> More Info </summary>
 
-The idea behind shadow deployments is that the clients/users have no idea about 
-the deployed version and the deployed version has **zero** impact on the 
-clients/users as the mirrored traffic happens out of band for the critical 
-request path for the primary service. 
+The idea behind shadow deployments is that the clients/users have no idea about
+the deployed version and the deployed version has **zero** impact on the
+clients/users as the mirrored traffic happens out of band for the critical
+request path for the primary service.
 
-Shadow deployments are particularly useful for load testing and refactoring of 
-monolithic applications. But they can be quite complex and care has to be taken 
-if there are interactions with other systems. Imagine shadow testing a payment 
-service for a shopping cart. You wouldn't want users paying twice for 
-an order. 
+Shadow deployments are particularly useful for load testing and refactoring of
+monolithic applications. But they can be quite complex and care has to be taken
+if there are interactions with other systems. Imagine shadow testing a payment
+service for a shopping cart. You wouldn't want users paying twice for
+an order.
 
 </details>
 
@@ -773,15 +773,15 @@ spec:
     mirrorPercentage:
       value: 100.0
 ```
-In the example above you can see that the `weight` field routes 100% of traffic 
-to the `v2` subset of `my-service`. The `mirror` field will route 100% of the 
-traffic `v2` receives to the `v3` subset. 
+In the example above you can see that the `weight` field routes 100% of traffic
+to the `v2` subset of `my-service`. The `mirror` field will route 100% of the
+traffic `v2` receives to the `v3` subset.
 
 
-Adjusting the `mirrorPercentage` value will adjust how much of the traffic 
-routed to `v2` will be mirrored to the `v3` subset. E.g, if set to 50.0 then 
-50% percent of traffic routed to the `v2` subset will be mirrored to the `v3` 
-subset. If the field is not defined then the `v3` subset will get 100% of the 
+Adjusting the `mirrorPercentage` value will adjust how much of the traffic
+routed to `v2` will be mirrored to the `v3` subset. E.g, if set to 50.0 then
+50% percent of traffic routed to the `v2` subset will be mirrored to the `v3`
+subset. If the field is not defined then the `v3` subset will get 100% of the
 traffic routed to `v2`.
 
 ### Overview
@@ -878,7 +878,7 @@ ___
 ./scripts/loop-query.sh
 ```
 
-You should **only** see responses from the `name-v2` workload. It should look 
+You should **only** see responses from the `name-v2` workload. It should look
 something like the following.
 
 ```
@@ -893,7 +893,7 @@ Athos (v2) is 92 years
 Porthos (v2) is 11 years
 Athos (v2) is 75 years
 ```
-> Requests mirrored to the `name-v3` workload are done as **fire and forget** 
+> Requests mirrored to the `name-v3` workload are done as **fire and forget**
 > requests. All **responses** are discarded.
 
 #### Task: Inspect the `name-v3` workload to see if it is receiving traffic
@@ -910,9 +910,9 @@ Get the logs with kubectl.
 
 ```console
 kubectl logs "$NAME_V3_POD" --tail=20 --follow
-``` 
+```
 
-You should see GET requests hitting the `name-v3` workload. It should look 
+You should see GET requests hitting the `name-v3` workload. It should look
 something like this.
 
 ```
@@ -934,15 +934,15 @@ WARNING:root:Operation 'name' took 0.238ms
 ___
 
 
-Go to Graph menu item and select the **Versioned app graph** from the drop 
+Go to Graph menu item and select the **Versioned app graph** from the drop
 down menu.
 
-If you look at the **version app graph** you **may** or **may not** see the 
+If you look at the **version app graph** you **may** or **may not** see the
 mirrored traffic being shown. It depends on the version of Kiali you are using.
 
 ![Graph with mirror](images/kiali-mirror-graph.png)
 
-But you know that the client is **not** getting 
+But you know that the client is **not** getting
 responses from `v3` from the terminals output.
 
 ```
@@ -958,12 +958,12 @@ Porthos (v2) is 11 years
 Athos (v2) is 75 years
 ```
 
-Go to the menu item **Workloads** and select `name-v3` and the **inbound** 
-metrics tab. 
+Go to the menu item **Workloads** and select `name-v3` and the **inbound**
+metrics tab.
 
-Metrics are also collected for the **destination** traffic of `v3`. If you 
-select **Source** from the **Reported from** drop down you will **not** 
-see any metrics as responses are discarded. 
+Metrics are also collected for the **destination** traffic of `v3`. If you
+select **Source** from the **Reported from** drop down you will **not**
+see any metrics as responses are discarded.
 
 ![Workload mirror metrics](images/kiali-mirrored-inbound-metrics.png)
 
@@ -973,11 +973,11 @@ see any metrics as responses are discarded.
 # Summary
 
 In these exercises you learned some of functionality provided by Istio's HTTPRoute.
-Implementing blue/green, canary and shadow deployment patterns. But there is a lot 
-more you can do. You can also manipulate headers, do HTTP redirects, 
-HTTP rewrites, etc. 
+Implementing blue/green, canary and shadow deployment patterns. But there is a lot
+more you can do. You can also manipulate headers, do HTTP redirects,
+HTTP rewrites, etc.
 
-See the [documentation](https://istio.io/latest/docs/reference/config/networking/virtual-service/#VirtualService) 
+See the [documentation](https://istio.io/latest/docs/reference/config/networking/virtual-service/#VirtualService)
 for a more complete overview of what you can do.
 
 The main takeaways are:
@@ -988,7 +988,7 @@ The main takeaways are:
 
 * You should always provide a default route when using a match
 
-* The **application** MUST propagate the headers in order for the virtual 
+* The **application** MUST propagate the headers in order for the virtual
 service to work with it
 
 # Cleanup

--- a/markdown-source/03-ingress-traffic.mdpp
+++ b/markdown-source/03-ingress-traffic.mdpp
@@ -250,7 +250,7 @@ Substitute the environment variable(s) and apply the output with kubectl.
 envsubst < 03-ingress-traffic/start/sentences-ingress-vs.yaml | kubectl apply -f -
 ```
 
-> :bulb: If want or need to do an environment substitution on multiple files
+> :bulb: If you want or need to do an environment substitution on multiple files
 > you can use a for loop to do so.
 > `for file in 03-ingress-traffic/start/*.yaml; do envsubst < $file | kubectl apply -f -; done`
 
@@ -336,6 +336,8 @@ should see that the request duration is trending towards five seconds.
 
 Similarly, the versioned graph view can show the 95th percentile of response times:
 
+> ❗ NB: only some versions of Kiali show the fault-injection response times.
+
 ![Sentences delay](images/kiali-sentences-fixed-delay-versioned-graph.png)
 
 
@@ -350,7 +352,7 @@ of the sentence service.
 
 Istio's default installation provide it's own configuration model (Gateway)
 for ingress traffic while also supporting Kubernetes ingress. The Istio
-gateway consists a deployment, a service and a **standalone** envoy proxy.
+gateway consists of a deployment, a service and a **standalone** envoy proxy.
 
 > The ingress gateway we used in our training environment is located in the
 > `istio-ingress` namespace.
@@ -358,11 +360,11 @@ gateway consists a deployment, a service and a **standalone** envoy proxy.
 The main takeaways are:
 
 * When you defined the gateway CRD for your namespace you configured an entry
-point in the stand alone envoy proxy
+point in the standalone envoy proxy
 
 * If traffic is not flowing through the mesh, e.g through the envoy sidecars,
 then you cannot leverage Istio features, e.g. the traffic between the gateway
-and your front end service
+and your frontend service
 
 # Cleanup
 

--- a/markdown-source/03-ingress-traffic.mdpp
+++ b/markdown-source/03-ingress-traffic.mdpp
@@ -9,44 +9,44 @@
 
 ## Introduction
 
-These exercises will introduce you to Istio concepts 
-and ([CRD's](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)) 
-for configuring traffic **into** the service mesh. This is commonly called 
-Ingress traffic. 
+These exercises will introduce you to Istio concepts
+and ([CRD's](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/))
+for configuring traffic **into** the service mesh. This is commonly called
+Ingress traffic.
 
-Istio does support 
-[Kubernetes Ingress](https://istio.io/latest/docs/tasks/traffic-management/ingress/kubernetes-ingress/) 
+Istio does support
+[Kubernetes Ingress](https://istio.io/latest/docs/tasks/traffic-management/ingress/kubernetes-ingress/)
 but also offers another configuration model.
 
-The Istio [IngressGateway](https://istio.io/latest/docs/tasks/traffic-management/ingress/ingress-control/) 
+The Istio [IngressGateway](https://istio.io/latest/docs/tasks/traffic-management/ingress/ingress-control/)
 which is what you will be using in this exercise.
 
-> :bulb: If you have not completed exercise 
-> [00-setup-introduction](00-setup-introduction.md) you **need** to label 
+> :bulb: If you have not completed exercise
+> [00-setup-introduction](00-setup-introduction.md) you **need** to label
 > your namespace with `istio-injection=enabled`.
 
 ## Exercise: Ingress Traffic With Gateway
 
-The previous exercises used a Kubernetes **NodePort** service to get traffic 
-to the sentences service. E.g. the **ingress** traffic to `sentences` **was 
-not** flowing through the Istio service mesh. 
+The previous exercises used a Kubernetes **NodePort** service to get traffic
+to the sentences service. E.g. the **ingress** traffic to `sentences` **was
+not** flowing through the Istio service mesh.
 
-From the `sentences` service to the `age` and `name` services traffic **was** 
-flowing through the Istio service mesh. We know this to be true because we 
+From the `sentences` service to the `age` and `name` services traffic **was**
+flowing through the Istio service mesh. We know this to be true because we
 have applied virtual services and destination rules to the `name` service.
 
 Ingressing traffic directly from the Kubernetes cluster network to a frontend
-service means that Istio features **cannot** be applied on this part of the 
+service means that Istio features **cannot** be applied on this part of the
 traffic flow.
 
-In this exercise you are going rectify this by **configuring** ingress traffic 
-to the sentences service through a dedicated **IngressGateway** (`istio-ingressgateway`) 
-provided by **Istio** instead of a Kubernetes NodePort. Furthermore you are going 
-to introduce a fixed delay to demonstrate that you can now apply Istio traffic 
+In this exercise you are going rectify this by **configuring** ingress traffic
+to the sentences service through a dedicated **IngressGateway** (`istio-ingressgateway`)
+provided by **Istio** instead of a Kubernetes NodePort. Furthermore you are going
+to introduce a fixed delay to demonstrate that you can now apply Istio traffic
 management to the sentences service.
 
-You are going to do this using the 
-[Gateway](https://istio.io/latest/docs/reference/config/networking/gateway/#Gateway) 
+You are going to do this using the
+[Gateway](https://istio.io/latest/docs/reference/config/networking/gateway/#Gateway)
 CRD which will **configure** an **entry point** in the Istio **IngressGateway**.
 
 > **Expand the example below for more details.**
@@ -76,32 +76,32 @@ spec:
 and the hosts exposed by the gateway. A host entry is specified as a DNS name
 and should be specified using the FQDN format.
 
-  > You can use a wildcard character in the **left-most** component of the 
-  > `hosts` field. E.g. `*.example.com`. 
-  > 
-  > You can also **prefix** the `hosts` field with a namespace. See the 
+  > You can use a wildcard character in the **left-most** component of the
+  > `hosts` field. E.g. `*.example.com`.
+  >
+  > You can also **prefix** the `hosts` field with a namespace. See the
   > [documentation](https://istio.io/latest/docs/reference/config/networking/gateway/#Server) for more details.
 
-- The **selectors** above are the labels on the `istio-ingressgateway` POD which 
+- The **selectors** above are the labels on the `istio-ingressgateway` POD which
 is the IngressGateway the traffic will be routed through.
 
-> Don't confuse the the **IngressGateway** with the Gateway custom resource 
+> Don't confuse the the **IngressGateway** with the Gateway custom resource
 > definition. The gateway CRD is used to **configure** the Ingressgateway.
-> The gateway defines and **entry point** to be exposed in the 
+> The gateway defines and **entry point** to be exposed in the
 > `istio-ingressgateway`. That is it. Nothing else.
 
 
 <details>
     <summary> More About IngressGateways </summary>
 
-An Istio **IngressGateway** **describes** a load balancer operating at the 
+An Istio **IngressGateway** **describes** a load balancer operating at the
 **edge** of the mesh receiving incoming or outgoing **HTTP/TCP** connections.
 
-An Istio **IngressGateway** in a Kubernetes cluster consists, at a minimum, 
-of a Deployment and a Service. Istio ingress gateways are based on Envoy 
-and have a **standalone** Envoy proxy. 
+An Istio **IngressGateway** in a Kubernetes cluster consists, at a minimum,
+of a Deployment and a Service. Istio ingress gateways are based on Envoy
+and have a **standalone** Envoy proxy.
 
-In our course environment we have an Istio **IngressGateway** in it's own 
+In our course environment we have an Istio **IngressGateway** in it's own
 namespace `istio-ingress`.
 
 This is the IngressGateway which we configure with a Gateway CRD.
@@ -111,9 +111,9 @@ This is the IngressGateway which we configure with a Gateway CRD.
 </details>
 
 
-In order to route the traffic we, of course, use a **virtual service**. The entry 
-point you configure with a GateWay CRD knows nothing about how to route the 
-traffic to the desired destination within the mesh. Therefor you use a virtual 
+In order to route the traffic we, of course, use a **virtual service**. The entry
+point you configure with a GateWay CRD knows nothing about how to route the
+traffic to the desired destination within the mesh. Therefor you use a virtual
 service specifying the **gateway** you defined.
 
 > **Expand the example below for more details.**
@@ -137,9 +137,9 @@ spec:
         host: myapp-frontend
 ```
 
-Note how it specifies the hostname and the name of the gateway 
-(in `spec.gateways`). A gateway definition can define an entry for many 
-hostnames and a VirtualService can be bound to multiple gateways, i.e. these 
+Note how it specifies the hostname and the name of the gateway
+(in `spec.gateways`). A gateway definition can define an entry for many
+hostnames and a VirtualService can be bound to multiple gateways, i.e. these
 are not necessarily related one-to-one.
 
 </details>
@@ -154,10 +154,10 @@ A general overview of what you will be doing in the **Step By Step** section.
 
 - Create an entry point for the sentences service
 
-> :bulb: In the yaml provided in the **Step By Step** section notice the 
-> placeholder environment variables (`$STUDENT_NS` and `$TRAINING_NAME`). 
-> When applying these you will be using the `envsubst` command to replace them 
-> with the values provided in the environment. 
+> :bulb: In the yaml provided in the **Step By Step** section notice the
+> placeholder environment variables (`$STUDENT_NS` and `$TRAINING_NAME`).
+> When applying these you will be using the `envsubst` command to replace them
+> with the values provided in the environment.
 
 - Create a route from the entry point to the sentences service
 
@@ -185,7 +185,7 @@ kubectl apply -f 03-ingress-traffic/start/
 ___
 
 
-Create a file called `sentences-ingress-gw.yaml` in 
+Create a file called `sentences-ingress-gw.yaml` in
 `03-ingress-traffic/start` directory.
 
 It should look like the below yaml.
@@ -219,7 +219,7 @@ envsubst < 03-ingress-traffic/start/sentences-ingress-gw.yaml | kubectl apply -f
 ___
 
 
-Create a file called `sentences-ingress-vs.yaml` in 
+Create a file called `sentences-ingress-vs.yaml` in
 `03-ingress-traffic/start` directory.
 
 It should look like the below yaml.
@@ -250,7 +250,7 @@ Substitute the environment variable(s) and apply the output with kubectl.
 envsubst < 03-ingress-traffic/start/sentences-ingress-vs.yaml | kubectl apply -f -
 ```
 
-> :bulb: If want or need to do an environment substitution on multiple files 
+> :bulb: If want or need to do an environment substitution on multiple files
 > you can use a for loop to do so.
 > `for file in 03-ingress-traffic/start/*.yaml; do envsubst < $file | kubectl apply -f -; done`
 
@@ -259,8 +259,8 @@ envsubst < 03-ingress-traffic/start/sentences-ingress-vs.yaml | kubectl apply -f
 ___
 
 
-The sentence service we deployed in the first step has a type of `ClusterIP` 
-now. In order to reach it we will need to go through the `istio-ingressgateway`. 
+The sentence service we deployed in the first step has a type of `ClusterIP`
+now. In order to reach it we will need to go through the `istio-ingressgateway`.
 
 Run the `loop-query.sh` script with the option `-g` and pass it the `hosts` entry.
 
@@ -273,11 +273,11 @@ Run the `loop-query.sh` script with the option `-g` and pass it the `hosts` entr
 ___
 
 
-Go to Graph menu item and select the **Versioned app graph** from the drop 
+Go to Graph menu item and select the **Versioned app graph** from the drop
 down menu.
 
-Now we can see that the traffic to the `sentences` service is no longer 
-**unknown** to the service mesh. 
+Now we can see that the traffic to the `sentences` service is no longer
+**unknown** to the service mesh.
 
 ![Ingress Gateway](images/kiali-ingress-gw.png)
 
@@ -286,8 +286,8 @@ Now we can see that the traffic to the `sentences` service is no longer
 ___
 
 
-To demonstrate that we can now apply Istio traffic management to the 
-sentences service. Add a fixed delay of 5 seconds to the 
+To demonstrate that we can now apply Istio traffic management to the
+sentences service. Add a fixed delay of 5 seconds to the
 `sentences-ingress-vs.yaml` file you created.
 
 ```yaml
@@ -317,7 +317,7 @@ Substitute the environment variable(s) and apply the output with kubectl.
 envsubst < 03-ingress-traffic/start/sentences-ingress-vs.yaml | kubectl apply -f -
 ```
 
-You should see that the response in the terminal are now taking 
+You should see that the response in the terminal are now taking
 approximately five seconds each.
 
 #### Task: Observe the traffic flow with Kiali
@@ -325,13 +325,13 @@ approximately five seconds each.
 ___
 
 
-Go to **Workloads** menu item, select `sentences-v1` workload and the 
-**Inbound Metrics** tab, **Reported from** in the **Source** drop down 
-menu and select checkboxes as shown in the below image. 
+Go to **Workloads** menu item, select `sentences-v1` workload and the
+**Inbound Metrics** tab, **Reported from** in the **Source** drop down
+menu and select checkboxes as shown in the below image.
 
 ![Sentences delay](images/kiali-sentences-fixed-delay.png)
 
-It may take a little bit before the graph updates but, eventually, you 
+It may take a little bit before the graph updates but, eventually, you
 should see that the request duration is trending towards five seconds.
 
 Similarly, the versioned graph view can show the 95th percentile of response times:
@@ -343,25 +343,25 @@ Similarly, the versioned graph view can show the 95th percentile of response tim
 
 # Summary
 
-In this exercise you saw how to route incoming traffic through an ingress gateway. 
-This allows you to apply istio traffic management features to the sentences 
-service. For example, you could do a blue/green deploy of two different versions 
+In this exercise you saw how to route incoming traffic through an ingress gateway.
+This allows you to apply istio traffic management features to the sentences
+service. For example, you could do a blue/green deploy of two different versions
 of the sentence service.
 
-Istio's default installation provide it's own configuration model (Gateway) 
-for ingress traffic while also supporting Kubernetes ingress. The Istio  
+Istio's default installation provide it's own configuration model (Gateway)
+for ingress traffic while also supporting Kubernetes ingress. The Istio
 gateway consists a deployment, a service and a **standalone** envoy proxy.
 
-> The ingress gateway we used in our training environment is located in the 
+> The ingress gateway we used in our training environment is located in the
 > `istio-ingress` namespace.
 
 The main takeaways are:
 
-* When you defined the gateway CRD for your namespace you configured an entry 
+* When you defined the gateway CRD for your namespace you configured an entry
 point in the stand alone envoy proxy
 
-* If traffic is not flowing through the mesh, e.g through the envoy sidecars, 
-then you cannot leverage Istio features, e.g. the traffic between the gateway 
+* If traffic is not flowing through the mesh, e.g through the envoy sidecars,
+then you cannot leverage Istio features, e.g. the traffic between the gateway
 and your front end service
 
 # Cleanup

--- a/markdown-source/04-egress-traffic.mdpp
+++ b/markdown-source/04-egress-traffic.mdpp
@@ -10,56 +10,56 @@
 
 ## Introduction
 
-This exercise will introduce you to Istio concepts 
-and ([CRD's](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)) 
-for configuring traffic **out** of the service mesh. This is commonly 
+This exercise will introduce you to Istio concepts
+and ([CRD's](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/))
+for configuring traffic **out** of the service mesh. This is commonly
 called Egress traffic.
 
-There are two Istio CRD's in addition to a virtual service needed for this. 
-The [Gateway](https://istio.io/latest/docs/reference/config/networking/gateway/#Gateway) 
-and the [ServiceEntry](https://istio.io/latest/docs/reference/config/networking/service-entry/#ServiceEntry) 
-CRD's. 
+There are two Istio CRD's in addition to a virtual service needed for this.
+The [Gateway](https://istio.io/latest/docs/reference/config/networking/gateway/#Gateway)
+and the [ServiceEntry](https://istio.io/latest/docs/reference/config/networking/service-entry/#ServiceEntry)
+CRD's.
 
-First you will route traffic **directly** to an external service from an internal 
-service with a service entry. Then you will route traffic from an internal 
-service through a common egress gateway. 
+First you will route traffic **directly** to an external service from an internal
+service with a service entry. Then you will route traffic from an internal
+service through a common egress gateway.
 
 This exercise builds on the [Getting Traffic Into The mesh](03-ingress-traffic.md) exercises.
 
-> :bulb: If you have not completed exercise 
-> [00-setup-introduction](00-setup-introduction.md) you **need** to label 
+> :bulb: If you have not completed exercise
+> [00-setup-introduction](00-setup-introduction.md) you **need** to label
 > your namespace with `istio-injection=enabled`.
 
 ## Exercise: Egress Traffic
 
-In this exercise you will deploy a **new** version of the **sentences** 
-service. This new version will use a new **API** service which does nothing 
-more than make a call to an external service ([httpbin](https://httpbin.org/)) 
-asking for a delay of 1 second for responses. You will then define a ServiceEntry 
-to allow traffic to the external service. After you have successfully reached 
+In this exercise you will deploy a **new** version of the **sentences**
+service. This new version will use a new **API** service which does nothing
+more than make a call to an external service ([httpbin](https://httpbin.org/))
+asking for a delay of 1 second for responses. You will then define a ServiceEntry
+to allow traffic to the external service. After you have successfully reached
 httpbin you will route the traffic through a common egress gateway.
 
 ### Service Entry
 
-A ServiceEntry allows you to apply Istio traffic management for services 
-running **outside** of your mesh. Your service might use an external API 
-as an example. Once you have defined a service entry you can configure 
-virtual services and destination rules to apply Istio features like 
-redirecting or forwarding traffic to external destinations, defining 
-retries, timeouts and fault injection policies. 
+A ServiceEntry allows you to apply Istio traffic management for services
+running **outside** of your mesh. Your service might use an external API
+as an example. Once you have defined a service entry you can configure
+virtual services and destination rules to apply Istio features like
+redirecting or forwarding traffic to external destinations, defining
+retries, timeouts and fault injection policies.
 
-> :bulb: In our environment we have set the outBoundTrafficPolicy to 
+> :bulb: In our environment we have set the outBoundTrafficPolicy to
 > `REGISTRY_ONLY`.
 
-By default, Istio configures Envoy proxies to **passthrough** requests to 
-unknown services. So, technically service entries are not required. But 
-without them you can't apply Istio features as the external service will be 
+By default, Istio configures Envoy proxies to **passthrough** requests to
+unknown services. So, technically service entries are not required. But
+without them you can't apply Istio features as the external service will be
 a black hole to the service mesh.
 
-There is also the security aspect to consider. While securely controlling 
-ingress traffic is the **highest** priority, it is good policy to securely 
-control egress traffic also. Because of this many clusters will have the 
-`outBoundTrafficPolicy` set to `REGISTRY_ONLY` as is done in our cluster. 
+There is also the security aspect to consider. While securely controlling
+ingress traffic is the **highest** priority, it is good policy to securely
+control egress traffic also. Because of this many clusters will have the
+`outBoundTrafficPolicy` set to `REGISTRY_ONLY` as is done in our cluster.
 This will force you to define your external services with a service entry.
 
 > **Expand the example below for more details.**
@@ -92,36 +92,36 @@ and destination rules. The `resolution` field is used to determine how the
 proxy will resolve IP addresses of the end points. The `exportTo` field scopes
 the service entry to the namespace where it is defined
 
-> :bulb: The `exportTo` field is important for this exercise. **Not** 
-> scoping the service entry to your namespace will open the external 
-> service for **all** attendees. 
+> :bulb: The `exportTo` field is important for this exercise. **Not**
+> scoping the service entry to your namespace will open the external
+> service for **all** attendees.
 
-When you create a service entry it is added to Istio's internal service 
-registry and traffic is allowed out of the mesh to the defined destination. 
+When you create a service entry it is added to Istio's internal service
+registry and traffic is allowed out of the mesh to the defined destination.
 
-Istio maintains an internal service registry containing the set of services, 
-and their corresponding service endpoints, running in a service mesh. 
+Istio maintains an internal service registry containing the set of services,
+and their corresponding service endpoints, running in a service mesh.
 Istio uses the service registry to generate Envoy configuration.
 
-> Istio does not provide service discovery, although most services are 
-> automatically added to the registry by Pilot adapters that reflect the 
-> discovered services of the underlying platform (Kubernetes, Consul, plain DNS). 
-> Additional services can also be registered manually using a ServiceEntry 
+> Istio does not provide service discovery, although most services are
+> automatically added to the registry by Pilot adapters that reflect the
+> discovered services of the underlying platform (Kubernetes, Consul, plain DNS).
+> Additional services can also be registered manually using a ServiceEntry
 > configuration.
 
 </details>
 
 ### Gateway
 
-Once a service entry is defined the traffic flows **directly** from the 
-workloads Envoy sidecar to the external service. 
+Once a service entry is defined the traffic flows **directly** from the
+workloads Envoy sidecar to the external service.
 
-But it is a pretty common use cases to have traffic leaving the mesh 
+But it is a pretty common use cases to have traffic leaving the mesh
 routed **via** a common **egress** gateway.
 
-A Gateway **describes** a load balancer operating at the **edge** of the mesh 
-receiving incoming or outgoing **HTTP/TCP** connections. The specification 
-describes the ports to be expose, type of protocol, configuration for the 
+A Gateway **describes** a load balancer operating at the **edge** of the mesh
+receiving incoming or outgoing **HTTP/TCP** connections. The specification
+describes the ports to be expose, type of protocol, configuration for the
 load balancer, etc.
 
 > **Expand the example below for more details.**
@@ -147,25 +147,25 @@ spec:
     - external-api.example.com
 ```
 
-The fields are the same as for the gateway defined for Ingress traffic to 
-the sentences service in a previous exercise. The notable difference being 
-that the **selectors** are now the labels on the **Egress** POD 
-`istio-egressgateway`, which is also running a standalone Envoy proxy just like 
+The fields are the same as for the gateway defined for Ingress traffic to
+the sentences service in a previous exercise. The notable difference being
+that the **selectors** are now the labels on the **Egress** POD
+`istio-egressgateway`, which is also running a standalone Envoy proxy just like
 the ingress gateway.
 
-The gateway defines an **exit point** to be exposed in the `istio-egressgateway`. 
-That is it. Nothing else. Just like an ingress entry point, it knows nothing 
-about how traffic is routed to it. 
+The gateway defines an **exit point** to be exposed in the `istio-egressgateway`.
+That is it. Nothing else. Just like an ingress entry point, it knows nothing
+about how traffic is routed to it.
 
-An Istio **Egress** gateway in a Kubernetes cluster consists, at a minimum, of a 
-Deployment and a Service. Istio egress gateways are based on Envoy and have a 
-**standalone** Envoy proxy. 
+An Istio **Egress** gateway in a Kubernetes cluster consists, at a minimum, of a
+Deployment and a Service. Istio egress gateways are based on Envoy and have a
+**standalone** Envoy proxy.
 
 Our course environment would show something like:
 
 ```
-NAME                                       TYPE                                   
-istio-egressgateway                        deployment  
+NAME                                       TYPE
+istio-egressgateway                        deployment
 istio-egressgateway                        service
 istio-egressgateway-8679c48588-2p8vw       pod
 ```
@@ -179,7 +179,7 @@ istio-egressgateway-8679c48588-2p8vw    istio-proxy
 
 </details>
 
-In order to route the traffic we, of course, use a virtual service. The GateWay 
+In order to route the traffic we, of course, use a virtual service. The GateWay
 just defines the **exit point** and we still need to define the route.
 
 > **Expand the example below for more details.**
@@ -212,18 +212,18 @@ spec:
       weight: 100
 ```
 
-- The route uses the reserved keyword `mesh` implying that this rule applies 
-to the sidecars in the mesh. 
+- The route uses the reserved keyword `mesh` implying that this rule applies
+to the sidecars in the mesh.
 
 - The exportTo field ensures the virtual service is applied only to the present
-namespace. 
+namespace.
 
 - The **full DNS name** of the `istio-egressgateway` service is defined instead
 of the shortname because the gateway is located in the `istio-system` namespace.
 
-> :bulb: Istio will translate a **short name** based one the **namespace** of the 
-> **rule**, e.g. if the virtual service is in the `default` namespace it will 
-> translate to `istio-egressgateway.default.svc.cluster.local`. So **full names** 
+> :bulb: Istio will translate a **short name** based one the **namespace** of the
+> **rule**, e.g. if the virtual service is in the `default` namespace it will
+> translate to `istio-egressgateway.default.svc.cluster.local`. So **full names**
 > should be used when using a gateway in another namespace.
 
 </details>
@@ -242,10 +242,10 @@ A general overview of what you will be doing in the **Step By Step** section.
 
 - Modify the the virtual service to route traffic through the **common** gateway
 
-> :bulb: The exit point for [httpbin](http://httpbin.org) and needed routes to 
-> the `istio-egressgateway` have already been created in the `istio-system` 
-> namespace. The role based access control (RBAC) in our training environment 
-> does **not** permit attendees to create resources in the `istio-system` 
+> :bulb: The exit point for [httpbin](http://httpbin.org) and needed routes to
+> the `istio-egressgateway` have already been created in the `istio-system`
+> namespace. The role based access control (RBAC) in our training environment
+> does **not** permit attendees to create resources in the `istio-system`
 > namespace.
 
 - Observe the traffic flow with Kiali
@@ -262,7 +262,7 @@ Expand the **Tasks** section below to do the exercise.
 ___
 
 
-Deploy `v2` of the sentences application services which has a new api service 
+Deploy `v2` of the sentences application services which has a new api service
 along with the ingress gateway entry point and virtual service.
 
 ```console
@@ -275,7 +275,7 @@ Make sure everything is in ready state.
 kubectl get gateway,se,vs,dr,svc,pods -n $STUDENT_NS
 ```
 
-You should now see a gateway, two virtual services and a destination rule along 
+You should now see a gateway, two virtual services and a destination rule along
 with four services and pods running. It should look something like below.
 
 ```
@@ -316,7 +316,7 @@ ___
 ___
 
 
-Export the pod as an environment variable. 
+Export the pod as an environment variable.
 
 ```console
 export API_POD=$(kubectl get pod -l app=sentences,mode=api -o jsonpath={.items..metadata.name})
@@ -328,7 +328,7 @@ Now tail the logs.
 kubectl logs "$API_POD" --tail=20 --follow
 ```
 
-You should see a response of 502(Bad Gateway) because there exists no service entry for 
+You should see a response of 502(Bad Gateway) because there exists no service entry for
 the external service httpbin.
 
 ```
@@ -342,12 +342,12 @@ WARNING:root:Operation 'api' took 306.376ms
 ___
 
 
-Go to Graph menu item and select the **Versioned app graph** from the drop 
+Go to Graph menu item and select the **Versioned app graph** from the drop
 down menu.
 
 ![No Service Entry](images/kiali-api-no-se.png)
 
-As there is no service entry all traffic to the external service is blocked 
+As there is no service entry all traffic to the external service is blocked
 and it is a **black hole** to the service mesh.
 
 #### Task: Define a service entry for httpbin.org
@@ -355,7 +355,7 @@ and it is a **black hole** to the service mesh.
 ___
 
 
-Create a service entry called `api-egress-se.yaml` in 
+Create a service entry called `api-egress-se.yaml` in
 `04-egress-traffic/start/`.
 
 ```yaml
@@ -407,12 +407,12 @@ WARNING:root:Operation 'api' took 1073.259ms
 ___
 
 
-Go to Graph menu item and select the **Versioned app graph** from the drop 
+Go to Graph menu item and select the **Versioned app graph** from the drop
 down menu.
 
 ![Service Entry](images/kiali-api-se.png)
 
-Now Kiali recognizes the external service because of the service entry and it 
+Now Kiali recognizes the external service because of the service entry and it
 is no longer a black hole.
 
 #### Task: Create a virtual service with a timeout of 0.5 seconds
@@ -420,14 +420,14 @@ is no longer a black hole.
 ___
 
 
-Basically all we have done so far is to add an entry for httpbin to Istio's 
-internal service registry. But we can now apply some of the Istio features to 
-the external service. To demonstrate this you will create a virtual service for 
+Basically all we have done so far is to add an entry for httpbin to Istio's
+internal service registry. But we can now apply some of the Istio features to
+the external service. To demonstrate this you will create a virtual service for
 traffic to httpbin with a timeout of `0.5s`.
 
 > The api service asks httpbin.org for a response delay of 1 second and since we are now enforcing a local timeout of 0.5s we are basically configuring the external call to timeout!
 
-Create a file called `api-egress-vs.yaml` in 
+Create a file called `api-egress-vs.yaml` in
 `04-egress-traffic/start/`.
 
 ```yaml
@@ -464,7 +464,7 @@ Tail the logs.
 kubectl logs "$API_POD" --tail=20 --follow
 ```
 
-Now you should be getting a 504(Gateway Timeout) response from the external service. 
+Now you should be getting a 504(Gateway Timeout) response from the external service.
 
 ```
 INFO:werkzeug:127.0.0.1 - - [10/Aug/2021 13:29:11] "GET / HTTP/1.1" 200 -
@@ -500,7 +500,7 @@ spec:
       port: 80
     route:
     - destination:
-        host: istio-egressgateway.istio-system.svc.cluster.local        
+        host: istio-egressgateway.istio-system.svc.cluster.local
         port:
           number: 80
       weight: 100
@@ -535,14 +535,14 @@ WARNING:root:Operation 'api' took 1080.768ms
 ___
 
 
-Go to Graph menu item and select the **Versioned app graph** from the drop 
+Go to Graph menu item and select the **Versioned app graph** from the drop
 down menu. Select the checkboxes as shown in the below image.
 
-You will see traffic to the sentences service entering through the ingress 
-gateway in the `istio-ingress` namespace. Traffic from the api service is now 
+You will see traffic to the sentences service entering through the ingress
+gateway in the `istio-ingress` namespace. Traffic from the api service is now
 leaving through the common egress gateway in the `istio-system` namespace.
 
-> Note depending on the version of Kiali in use the graph may look disconnected 
+> Note depending on the version of Kiali in use the graph may look disconnected
 > between the api service and the external service.
 
 ![API Egress](images/kiali-api-egress.png)
@@ -551,26 +551,26 @@ leaving through the common egress gateway in the `istio-system` namespace.
 
 # Summary
 
-In this exercise you created a service entry to allow access to an 
-external service. This is a pretty common use case. A lot of service 
-meshes will have a `REGISTRY_ONLY` policy defined for security reasons. 
+In this exercise you created a service entry to allow access to an
+external service. This is a pretty common use case. A lot of service
+meshes will have a `REGISTRY_ONLY` policy defined for security reasons.
 So you should be aware of what a service entry does.
 
-Afterwards you created a virtual service to demonstrate Istio traffic 
-management for traffic to an external service. Finally, you routed the 
-traffic to the external service through a **common** egress gateway. 
+Afterwards you created a virtual service to demonstrate Istio traffic
+management for traffic to an external service. Finally, you routed the
+traffic to the external service through a **common** egress gateway.
 
 The main takeaways are:
 
-- If traffic is **not** flowing through the mesh, e.g through the 
-envoy sidecars, then you cannot leverage Istio features. Regardless 
+- If traffic is **not** flowing through the mesh, e.g through the
+envoy sidecars, then you cannot leverage Istio features. Regardless
 of whether it is ingress or egress traffic.
 
-- Service entries are needed if the **default** passthrough logic to 
+- Service entries are needed if the **default** passthrough logic to
 external service is disabled.
 
-- Gateways define an exit point for load balancer operating at the edge of 
-the mesh. You still need to route traffic to the gateway and the external 
+- Gateways define an exit point for load balancer operating at the edge of
+the mesh. You still need to route traffic to the gateway and the external
 service.
 
 # Cleanup

--- a/markdown-source/04-egress-traffic.mdpp
+++ b/markdown-source/04-egress-traffic.mdpp
@@ -179,7 +179,7 @@ istio-egressgateway-8679c48588-2p8vw    istio-proxy
 
 </details>
 
-In order to route the traffic we, of course, use a virtual service. The GateWay
+In order to route the traffic we, of course, use a virtual service. The gateway
 just defines the **exit point** and we still need to define the route.
 
 > **Expand the example below for more details.**

--- a/markdown-source/05-securing-with-mtls.mdpp
+++ b/markdown-source/05-securing-with-mtls.mdpp
@@ -14,31 +14,31 @@ These exercises will demonstrate how to use mutual TLS inside the mesh between
 PODs with the Istio sidecar injected and also from mesh-external services
 accessing the mesh through an ingress gateway.
 
-You will be using several Istio custom resource 
-definitions([CRD's](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)) 
+You will be using several Istio custom resource
+definitions([CRD's](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/))
 for this.
 
-- [PeerAuthentication](https://istio.io/latest/docs/reference/config/security/peer_authentication/#PeerAuthentication-MutualTLS) - 
+- [PeerAuthentication](https://istio.io/latest/docs/reference/config/security/peer_authentication/#PeerAuthentication-MutualTLS) -
 Applies to requests that a service **receives**
 
-- [DestinationRule](https://istio.io/latest/docs/reference/config/networking/destination-rule/#DestinationRule) - 
+- [DestinationRule](https://istio.io/latest/docs/reference/config/networking/destination-rule/#DestinationRule) -
 What type of TLS sidecar **sends**
 
-- [Gateway](https://istio.io/latest/docs/reference/config/networking/gateway/#ServerTLSSettings) - 
+- [Gateway](https://istio.io/latest/docs/reference/config/networking/gateway/#ServerTLSSettings) -
 Specify TLS settings for external service
 
-Istio provides two types of authentication policies of which *peer 
-authentication* is one of them. 
+Istio provides two types of authentication policies of which *peer
+authentication* is one of them.
 
-Peer authentication is used for **service-to-service** authentication 
-to verify the client making the connection and secure the 
-service-to-service communication. Istio uses 
-[mutual TLS](https://en.wikipedia.org/wiki/Mutual_authentication)(mTLS) 
-for transport authentication. 
+Peer authentication is used for **service-to-service** authentication
+to verify the client making the connection and secure the
+service-to-service communication. Istio uses
+[mutual TLS](https://en.wikipedia.org/wiki/Mutual_authentication)(mTLS)
+for transport authentication.
 
-This provides a **strong identity** for each workload. 
+This provides a **strong identity** for each workload.
 
-> Istio has it's own certificate authority(CA) and securely provisions strong 
+> Istio has it's own certificate authority(CA) and securely provisions strong
 > identities to every workload with X.509 certificates.
 
 <details>
@@ -48,30 +48,30 @@ Istio provisions keys and certificates through the following flow:
 
 - istiod offers a gRPC service to take certificate signing requests (CSRs).
 
-- When started, the Istio agent creates the private key and CSR, and then 
+- When started, the Istio agent creates the private key and CSR, and then
 sends the CSR with its credentials to istiod for signing.
 
-- The CA in istiod validates the credentials carried in the CSR. Upon 
+- The CA in istiod validates the credentials carried in the CSR. Upon
 successful validation, it signs the CSR to generate the certificate.
 
-- When a workload is started, Envoy requests the certificate and key from 
-the Istio agent in the same container via the Envoy secret discovery 
+- When a workload is started, Envoy requests the certificate and key from
+the Istio agent in the same container via the Envoy secret discovery
 service (SDS) API.
 
-- The Istio agent sends the certificates received from istiod and the private 
+- The Istio agent sends the certificates received from istiod and the private
 key to Envoy via the Envoy SDS API.
 
-- Istio agent monitors the expiration of the workload certificate. 
+- Istio agent monitors the expiration of the workload certificate.
 
 > The above process repeats periodically for certificate and key rotation.
 
 </details>
 
-Peer authentication is normally enabled at the `mesh` level, as in our 
-training infrastructure, which means traffic is secured by **default** 
-for all services in the cluster **without** requiring code changes. 
+Peer authentication is normally enabled at the `mesh` level, as in our
+training infrastructure, which means traffic is secured by **default**
+for all services in the cluster **without** requiring code changes.
 
-There are four modes that can be set for mTLS. They are `UNSET`, `DISABLE`, 
+There are four modes that can be set for mTLS. They are `UNSET`, `DISABLE`,
 `PERMISSIVE` and `STRICT`.
 
 <details>
@@ -79,7 +79,7 @@ There are four modes that can be set for mTLS. They are `UNSET`, `DISABLE`,
 
 - `UNSET` - Modes is inherited from parent, defaults to PERMISSIVE
 
-- `DISABLE` - Connection is **not** tunneled 
+- `DISABLE` - Connection is **not** tunneled
 
 - `PERMISSIVE` - Connection can be either plaintext or mTLS tunnel
 
@@ -89,21 +89,21 @@ There are four modes that can be set for mTLS. They are `UNSET`, `DISABLE`,
 
 </details>
 
-> :bulb: If you have not completed exercise 
-> [00-setup-introduction](00-setup-introduction.md) you **need** to label 
+> :bulb: If you have not completed exercise
+> [00-setup-introduction](00-setup-introduction.md) you **need** to label
 > your namespace with `istio-injection=enabled`.
 
 ## Exercise: Mutual TLS Inside the Mesh
 
-You will deploy all the services for the sentences application to observe 
-the affects of mTLS configuration. You will first observe that the default 
-mesh wide configuration will be inherited by your namespace. Afterwards you 
-will apply mTLS configuration to **your** namespace and observe the affects 
+You will deploy all the services for the sentences application to observe
+the affects of mTLS configuration. You will first observe that the default
+mesh wide configuration will be inherited by your namespace. Afterwards you
+will apply mTLS configuration to **your** namespace and observe the affects
 of STRICT and PERMISSIVE policies.
 
 ### PeerAuthentication
 
-The PeerAuthentication CRD is used to specify the mTLS settings for a workloads 
+The PeerAuthentication CRD is used to specify the mTLS settings for a workloads
 **requests**.
 
 An example of a peer authentication policy is seen below:
@@ -131,30 +131,30 @@ spec:
     mode: STRICT
 ```
 
-The above policy says to allow **both** plain-text and mTLS traffic for **all** 
-workloads in the `foo` namespace but **require** mTLS for the workload `myapp` 
+The above policy says to allow **both** plain-text and mTLS traffic for **all**
+workloads in the `foo` namespace but **require** mTLS for the workload `myapp`
 in the `foo` namespace.
 
 - The `namespace` definition scopes the policy to the defined namespace.
-If a policy is **not** namespace scoped it applies to **all** workloads 
+If a policy is **not** namespace scoped it applies to **all** workloads
 within the mesh.
 
-> There can be only one **mesh-wide** peer authentication policy, and only one 
-> **namespace-wide** peer authentication policy per namespace. If you configure 
+> There can be only one **mesh-wide** peer authentication policy, and only one
+> **namespace-wide** peer authentication policy per namespace. If you configure
 > more then Istio will **ignore the newer policies**.
 
 - The `selector` determines the workload to apply the PeerAuthentication to.
 
-> You can also specify the mTLS mode at the **port** level **if** you specify 
-a `selector`. 
+> You can also specify the mTLS mode at the **port** level **if** you specify
+a `selector`.
 
 ### DestinationRule
 
-The DestinationRule CRD is used to specify the TLS settings for upstream 
-connections. E.g. traffic the workload sends. These settings are common for 
-both HTTP and TCP connections. 
+The DestinationRule CRD is used to specify the TLS settings for upstream
+connections. E.g. traffic the workload sends. These settings are common for
+both HTTP and TCP connections.
 
-In a destination rule you use the `tls` keyword instead of the `mtls` keyword 
+In a destination rule you use the `tls` keyword instead of the `mtls` keyword
 under `spec.trafficPolicy`.
 
 ```yaml
@@ -172,8 +172,8 @@ spec:
       caCertificates: /etc/certs/rootcacerts.pem
 ```
 
-The modes are `DISABLE`, `SIMPLE`, `MUTUAL` and `ISTIO_MUTUAL`. For services 
-within the mesh `ISTIO_MUTUAL` is the natural choice as it uses Istio's 
+The modes are `DISABLE`, `SIMPLE`, `MUTUAL` and `ISTIO_MUTUAL`. For services
+within the mesh `ISTIO_MUTUAL` is the natural choice as it uses Istio's
 generated certs and they do not need to be specified in the destination rule.
 
 <details>
@@ -183,12 +183,12 @@ generated certs and they do not need to be specified in the destination rule.
 
 - `SIMPLE` - Originate a TLS connection to the upstream endpoint.
 
-- `MUTUAL` - Secure connections to the upstream using **mutual** TLS by 
+- `MUTUAL` - Secure connections to the upstream using **mutual** TLS by
 presenting client certificates for authentication.
 
 > You **must** specify the certificates when modes is set to MUTUAL.
 
-- `ISTIO_MUTUAL` - Same as MUTUAL except you do **not** specify the 
+- `ISTIO_MUTUAL` - Same as MUTUAL except you do **not** specify the
 client certificates as the certs generated for mTLS by Istio are used.
 
 </details>
@@ -199,7 +199,7 @@ A general overview of what you will be doing in the **Step By Step** section.
 
 - Deploy the sentences application services and see the effect of mesh wide mTLS config
 
-- Apply a STRICT and PERMISSIVE mTLS policy to **your** namespace and observe 
+- Apply a STRICT and PERMISSIVE mTLS policy to **your** namespace and observe
 the affects
 
 - Observe the affects on a service without a sidecar
@@ -218,18 +218,18 @@ Expand the **Tasks** section below to do the exercise.
 ___
 
 
-Run a for loop to substitute placeholders for environment variables and deploy 
-the services along with an ingress gateway and virtual service for routing 
+Run a for loop to substitute placeholders for environment variables and deploy
+the services along with an ingress gateway and virtual service for routing
 inbound traffic.
 
 ```console
 for file in 05-securing-with-mtls/start/*.yaml; do envsubst < $file | kubectl apply -f -; done
 ```
 
-Observe that the services are ready and we have a sidecar container per POD and 
+Observe that the services are ready and we have a sidecar container per POD and
 the sentences service is exposed with NodePort.
 
-> :bulb: We have also configured an entry point with a Gateway and VirtualService 
+> :bulb: We have also configured an entry point with a Gateway and VirtualService
 > but are also exposing it as a NodePort to demonstrate the effects of the policies.
 
 ```console
@@ -256,7 +256,7 @@ service/sentences   NodePort    172.20.92.234    <none>        5000:30962/TCP   
 ___
 
 
-Run the loop-query.sh script without parameters to reach the service over the 
+Run the loop-query.sh script without parameters to reach the service over the
 NodePort.
 
 ```console
@@ -267,18 +267,18 @@ NodePort.
 
 ___
 
-Go to Graph menu item and select the **Versioned app graph** from the drop 
-down menu. 
+Go to Graph menu item and select the **Versioned app graph** from the drop
+down menu.
 
-Check the display options as shown in the image below. Especially the **Security** 
-checkbox. 
+Check the display options as shown in the image below. Especially the **Security**
+checkbox.
 
-Notice the lock icons, which indicate whether the traffic is encrypted between 
+Notice the lock icons, which indicate whether the traffic is encrypted between
 the services.
 
-Select one of the **arrows** with a lock icon. You will be able to see on the 
-sidebar that the traffic is mTLS secured. Notice that traffic from the 
-`loop-query.sh` script(unknown) to the sentences frontend service is plain text 
+Select one of the **arrows** with a lock icon. You will be able to see on the
+sidebar that the traffic is mTLS secured. Notice that traffic from the
+`loop-query.sh` script(unknown) to the sentences frontend service is plain text
 HTTP traffic as we are using a NodePort to access it.
 
 ![Kiali default mTLS](images/kiali-mtls-default.png)
@@ -287,7 +287,7 @@ HTTP traffic as we are using a NodePort to access it.
 
 ___
 
-Create a file called `peer-authentication.yaml` in 
+Create a file called `peer-authentication.yaml` in
 `05-securing-with-mtls/start/`.
 
 Paste the following yaml into the file.
@@ -303,11 +303,11 @@ spec:
     mode: STRICT
 ```
 
-> :bulb: Note `$STUDENT_NS` in the above yaml. It is important that the 
-> PeerAuthentication CRD is scoped to **your individual** namespace. There can 
+> :bulb: Note `$STUDENT_NS` in the above yaml. It is important that the
+> PeerAuthentication CRD is scoped to **your individual** namespace. There can
 > only be one mesh wide and one namespace wide policy at a time.
 
-Substitute the placeholder with the value of the environment variable and apply 
+Substitute the placeholder with the value of the environment variable and apply
 the output with kubectl.
 
 ```console
@@ -323,11 +323,11 @@ Aramis (v2) is 35 years.
 curl: (56) Recv failure: Connection reset by peer
 ```
 
-You just applied a STRICT policy **requiring** all traffic to be over mTLS but 
-are accessing the frontend service directly over a NodePort and the traffic is 
+You just applied a STRICT policy **requiring** all traffic to be over mTLS but
+are accessing the frontend service directly over a NodePort and the traffic is
 plain-text over HTTP.
 
-Change the mode to `PERMISSIVE` in the `peer-authentication.yaml` file you just 
+Change the mode to `PERMISSIVE` in the `peer-authentication.yaml` file you just
 created.
 
 ```yaml
@@ -351,20 +351,20 @@ envsubst < 05-securing-with-mtls/start/peer-authentication.yaml | kubectl apply 
 
 ___
 
-Re-run the `loop-query.sh` script as before so we access the sentences frontend 
+Re-run the `loop-query.sh` script as before so we access the sentences frontend
 service over the NodePort as before.
 
 ```console
 ./scripts/loop-query.sh
 ```
 
-Go to Graph menu item and select the **Versioned app graph** from the drop 
-down menu. 
+Go to Graph menu item and select the **Versioned app graph** from the drop
+down menu.
 
-Check the display options as shown in the image below. Especially the 
-**Security** checkbox. 
+Check the display options as shown in the image below. Especially the
+**Security** checkbox.
 
-Notice that traffic is plain text HTTP traffic and is now allowed as 
+Notice that traffic is plain text HTTP traffic and is now allowed as
 `PERMISSIVE` mode allows both plain-text and mTLS.
 
 ![Kiali default mTLS](images/kiali-mtls-default.png)
@@ -386,23 +386,23 @@ loop-query.sh script with the option -g.
 
 ___
 
-Go to Graph menu item and select the **Versioned app graph** from the drop 
-down menu. 
+Go to Graph menu item and select the **Versioned app graph** from the drop
+down menu.
 
 Select the `istio-ingress` namespace along with your namespace and select the
 display checkboxes as shown below.
 
 ![Kiali with no sidecars](images/kiali-mtls-gw.png)
 
-We can now see that all the traffic within the mesh is mTLS. As the traffic is 
-now being routed through the ingress gateway it is being secured over mTLS by 
-the gateways standalone envoy proxy towards the sentences frontend service. 
+We can now see that all the traffic within the mesh is mTLS. As the traffic is
+now being routed through the ingress gateway it is being secured over mTLS by
+the gateways standalone envoy proxy towards the sentences frontend service.
 
-When `PERMISSIVE` mode is enabled both plain-text traffic and mTLS traffic are 
-allowed but mTLS **will be applied where possible**. 
+When `PERMISSIVE` mode is enabled both plain-text traffic and mTLS traffic are
+allowed but mTLS **will be applied where possible**.
 
-There is no real reason, besides for demonstration purposes, to expose the 
-sentences frontend service as a NodePort. Change the sentences service type to 
+There is no real reason, besides for demonstration purposes, to expose the
+sentences frontend service as a NodePort. Change the sentences service type to
 `ClusterIP` in the `sentences.yaml` file in `05-securing-with-mtls/start` folder.
 
 ```yaml
@@ -433,8 +433,8 @@ spec:
 
 ___
 
-As all of the traffic is now going through the ingress gateway you can apply 
-`STRICT` mode to your policy now. Change it in the `peer-authentication.yaml` 
+As all of the traffic is now going through the ingress gateway you can apply
+`STRICT` mode to your policy now. Change it in the `peer-authentication.yaml`
 file you created.
 
 Apply your changes.
@@ -443,8 +443,8 @@ Apply your changes.
 for file in 05-securing-with-mtls/start/*.yaml; do envsubst < $file | kubectl apply -f -; done
 ```
 
-> While migrating an application to full mTLS, it may be useful to start with 
-> a `PERMISSIVE` mTLS mode which allow a mix of mTLS and un-encrypted and 
+> While migrating an application to full mTLS, it may be useful to start with
+> a `PERMISSIVE` mTLS mode which allow a mix of mTLS and un-encrypted and
 > un-authenticated traffic.
 
 #### Task: Disable sidecar for the age service
@@ -453,7 +453,7 @@ ___
 
 What do you think will happen if a service has **no sidecar**?
 
-Modify the age service so it has no sidecar by adding an annotation to the file 
+Modify the age service so it has no sidecar by adding an annotation to the file
 `age.yaml` in `05-securing-with-mtls/start` folder to disable sidecar injection.
 
 The deployment section of the file should look like.
@@ -511,7 +511,7 @@ pod/age-v1-54fc4584d6-k94zk         1/1     Running       0          13s
 pod/age-v1-6d5946d477-f7fdp         2/2     Terminating   0          57m
 ```
 
-You really shouldn't see any interruptions from the `loop-query.sh` script 
+You really shouldn't see any interruptions from the `loop-query.sh` script
 running in the terminal.
 
 If a POD has no sidecar then the PeerAuthentication policy **cannot be applied**.
@@ -521,14 +521,14 @@ If a POD has no sidecar then the PeerAuthentication policy **cannot be applied**
 ___
 
 
-Go to Graph menu item and select the **Versioned app graph** from the drop 
-down menu. 
+Go to Graph menu item and select the **Versioned app graph** from the drop
+down menu.
 
 Select the `istio-ingress` namespace along with your namespace and select the
 display checkboxes as shown below.
 
-As the age service has no sidecar you will, **eventually**, not be able to see 
-traffic flowing to the age service in the graph even though it is still flowing 
+As the age service has no sidecar you will, **eventually**, not be able to see
+traffic flowing to the age service in the graph even though it is still flowing
 over HTTP.
 
 ![Kiali mTLS no age sidecar](images/kiali-mtls-no-age-service.png)
@@ -546,11 +546,11 @@ ___
 
 To show how we can control upstream mTLS settings with a DestinationRule, we
 create one that uses mTLS towards `v2` of the `name` service and no mTLS for
-`v1`. 
+`v1`.
 
 > :bulb: Note that we now need to use a `PERMISSIVE` Policy.
 
-Modify the `peer-authentication.yaml` in `05-securing-with-mtls/start/` 
+Modify the `peer-authentication.yaml` in `05-securing-with-mtls/start/`
 to use `PERMISSIVE` mode.
 
 ```yaml
@@ -564,7 +564,7 @@ spec:
     mode: PERMISSIVE
 ```
 
-Substitute the placeholder with the value of the environment variable and apply 
+Substitute the placeholder with the value of the environment variable and apply
 the output with kubectl.
 
 ```console
@@ -572,10 +572,10 @@ envsubst < 05-securing-with-mtls/start/peer-authentication.yaml | kubectl apply 
 ```
 
 Note, that a DestinationRule *will not* take effect until a route rule
-explicitly sends traffic to a subset. So you need both a virtual 
-service and a destination rule. 
+explicitly sends traffic to a subset. So you need both a virtual
+service and a destination rule.
 
-Create a file called `name-vs-dr.yaml` in `05-securing-with-mtls/start/` 
+Create a file called `name-vs-dr.yaml` in `05-securing-with-mtls/start/`
 directory.
 
 ```yaml
@@ -639,7 +639,7 @@ kubectl apply -f 05-securing-with-mtls/start/name-vs-dr.yaml
 ___
 
 
-Go to Graph menu item and select the **Versioned app graph** from the drop 
+Go to Graph menu item and select the **Versioned app graph** from the drop
 down menu. Select the checkboxes as shown in the below image.
 
 Now we see a missing padlock on the traffic towards `v1` of the name service.
@@ -650,15 +650,15 @@ Now we see a missing padlock on the traffic towards `v1` of the name service.
 
 ## Exercise: Mutual TLS From External Clients
 
-This exercise extends what we have done so far to demonstrate a common 
-use case of configuring mTLS with a service **external** to the mesh. A 
-service running in a different mesh for example. 
+This exercise extends what we have done so far to demonstrate a common
+use case of configuring mTLS with a service **external** to the mesh. A
+service running in a different mesh for example.
 
-In order to do this we will create a Certificate authority and certificates 
+In order to do this we will create a Certificate authority and certificates
 to enable strong workload identity.
 
-The TLS settings to control this will be defined in the 
-[Gateway](https://istio.io/latest/docs/reference/config/networking/gateway/#Gateway) 
+The TLS settings to control this will be defined in the
+[Gateway](https://istio.io/latest/docs/reference/config/networking/gateway/#Gateway)
 CRD.
 
 ```yaml
@@ -684,24 +684,24 @@ spec:
 
 ```
 
-- The port and tls blocks define the protocol and TLS mode to apply the 
-configuration to. In this exercise you will be using the `SIMPLE` and 
-the `MUTUAL` TLS modes. See this link for more information about 
+- The port and tls blocks define the protocol and TLS mode to apply the
+configuration to. In this exercise you will be using the `SIMPLE` and
+the `MUTUAL` TLS modes. See this link for more information about
 [Server TLS modes](https://istio.io/latest/docs/reference/config/networking/gateway/#ServerTLSSettings-TLSmode).
 
-- The credentialName represents a kubernetes secret containing the server side 
+- The credentialName represents a kubernetes secret containing the server side
 certificate.
 
-> :bulb: The secret **must** be in the **same** namespace as the ingress gateway 
-> controller. The gateway must be **namespaced** to be in the same namespace as 
-> the kubernetes secret. So **both** must be in the `istio-ingress` namespace in 
+> :bulb: The secret **must** be in the **same** namespace as the ingress gateway
+> controller. The gateway must be **namespaced** to be in the same namespace as
+> the kubernetes secret. So **both** must be in the `istio-ingress` namespace in
 > the above example and the gateway **must** be unique for this exercise.
 
 ### Overview
 
 A general overview of what you will be doing in the **Step By Step** section.
 
-- Generate needed certificate authority(CA) and certificates 
+- Generate needed certificate authority(CA) and certificates
 
 - Require `MUTUAL` TLS for port `443`
 
@@ -720,7 +720,7 @@ Expand the **Tasks** section below to do the exercise.
 
 ___
 
-Ensure that the gateway and virtual service for the `sentences` 
+Ensure that the gateway and virtual service for the `sentences`
 service from the first exercise is removed.
 
 ```console
@@ -738,10 +738,10 @@ Execute the `generate-certs.sh`script.
 ```console
 ./scripts/generate-certs.sh
 ```
-You should see namespace specific certs for both the server side and 
+You should see namespace specific certs for both the server side and
 client side in your workspace.
 
-There should also be a kubernetes secret in the `istio-ingress` namespace. 
+There should also be a kubernetes secret in the `istio-ingress` namespace.
 
 ```console
 kubectl get secrets -n istio-ingress
@@ -760,8 +760,8 @@ student1-sentences-tls-secret        Opaque    3      112m
 ___
 
 
-Modify the file `05-securing-with-mtls/start/sentences-ingress-gw.yaml` so 
-that it will be namespaced to the `istio-ingress` namespace and configure it 
+Modify the file `05-securing-with-mtls/start/sentences-ingress-gw.yaml` so
+that it will be namespaced to the `istio-ingress` namespace and configure it
 for `MUTUAL` TLS on port 443.
 
 ```yaml
@@ -791,7 +791,7 @@ spec:
 ___
 
 
-The gateway is now namespaced to the `istio-ingress` namespace so you need 
+The gateway is now namespaced to the `istio-ingress` namespace so you need
 to tell the virtual service which namespace the gateway is located in.
 
 Modify the file `05-securing-with-mtls/start/sentences-ingress-vs.yaml`.
@@ -817,7 +817,7 @@ spec:
 ___
 
 
-Once you have done the modifications to the gateway and virtual service, 
+Once you have done the modifications to the gateway and virtual service,
 substitute the placeholders with environment variable(s) and apply with kubectl.
 
 ```console
@@ -830,17 +830,17 @@ envsubst < 05-securing-with-mtls/start/sentences-ingress-vs.yaml | kubectl apply
 ___
 
 
-The `loop-query-mtls.sh` script uses the `client` certificates that were 
-generated for the mtls connection. 
+The `loop-query-mtls.sh` script uses the `client` certificates that were
+generated for the mtls connection.
 
 ```console
 scripts/loop-query-mtls.sh https+mtls
 ```
 
-Note the curl options printed when the script starts. The certificate 
+Note the curl options printed when the script starts. The certificate
 authority **and** the client cert, which is required for mTLS, are specified.
 
-It will look *something* like below but with the CA and client certs that can 
+It will look *something* like below but with the CA and client certs that can
 be found in your workspace as the below has been edited for simplicity.
 
 ```
@@ -860,9 +860,9 @@ ___
 scripts/loop-query-mtls.sh https
 ```
 
-**You should see an OpenSSL error**! Note the curl options printed when the 
-script starts. **Only** the **certificate authority** is passed as simple TLS 
-only requires server side authentication. But we have configured our gateway 
+**You should see an OpenSSL error**! Note the curl options printed when the
+script starts. **Only** the **certificate authority** is passed as simple TLS
+only requires server side authentication. But we have configured our gateway
 to use `MUTUAL` TLS. E.g.both client and server side authenticate.
 
 ```
@@ -878,10 +878,10 @@ Change the TLS mode to `SIMPLE` and apply the change.
 envsubst < 05-securing-with-mtls/start/sentences-ingress-gw.yaml | kubectl apply -f -
 ```
 
-Plain `https` will now work. 
+Plain `https` will now work.
 
-> You can still pass the `https+mtls` argument to the script and a connection 
-> will be made. Only server side authentication will be done. E.g. Istio will 
+> You can still pass the `https+mtls` argument to the script and a connection
+> will be made. Only server side authentication will be done. E.g. Istio will
 > simply **ignore** the client certs passed through the curl options.
 
 </details>
@@ -900,14 +900,14 @@ The main takeaways are:
 
 - Peer authentication policies only apply to workloads with a sidecar
 
-- Peer authentication policies apply to the **all** workloads within the 
+- Peer authentication policies apply to the **all** workloads within the
 mesh if **not** namespaced
 
 - The `STRICT` policy means strict and a `PERMISSIVE` policy is a good way to get started
 
 - Destination rules configure TLS for a workloads upstream traffic
 
-- When securing external traffic through ingress gateways you need to 
+- When securing external traffic through ingress gateways you need to
 consider namespaces in relation to kubernetes secrets and gateway controllers.
 
 ## Cleanup

--- a/markdown-source/05-securing-with-mtls.mdpp
+++ b/markdown-source/05-securing-with-mtls.mdpp
@@ -643,6 +643,8 @@ Go to Graph menu item and select the **Versioned app graph** from the drop
 down menu. Select the checkboxes as shown in the below image.
 
 Now we see a missing padlock on the traffic towards `v1` of the name service.
+(It might take a second to update, but if you select the connection,
+you may already be able to see the "percentage of mTLS" traffic decreasing.)
 
 ![No mTLS towards v1](images/kiali-mtls-destrule-anno.png)
 
@@ -900,7 +902,7 @@ The main takeaways are:
 
 - Peer authentication policies only apply to workloads with a sidecar
 
-- Peer authentication policies apply to the **all** workloads within the
+- Peer authentication policies apply to **all** the workloads within the
 mesh if **not** namespaced
 
 - The `STRICT` policy means strict and a `PERMISSIVE` policy is a good way to get started

--- a/markdown-source/06-service-access-control.mdpp
+++ b/markdown-source/06-service-access-control.mdpp
@@ -15,17 +15,17 @@ This exercise will demonstrate how to authorize access between components of our
 application such that services only have the access they need, not more. This is
 the *least privilege security principle*.
 
-First you will control service to service access with native kubernetes 
-network policies to understand what is possible and what is not. 
+First you will control service to service access with native kubernetes
+network policies to understand what is possible and what is not.
 
-Then you will use a Istio custom resource 
-definition([CRD](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)) 
-to understand what Istio functionality can be used to control service 
-to service access. The Istio CRD for this is the 
+Then you will use a Istio custom resource
+definition([CRD](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/))
+to understand what Istio functionality can be used to control service
+to service access. The Istio CRD for this is the
 [AuthorizationPolicy](https://istio.io/latest/docs/reference/config/security/authorization-policy/).
 
-> :bulb: If you have not completed exercise 
-> [00-setup-introduction](00-setup-introduction.md) you **need** to label 
+> :bulb: If you have not completed exercise
+> [00-setup-introduction](00-setup-introduction.md) you **need** to label
 > your namespace with `istio-injection=enabled`.
 
 ## Exercise
@@ -75,12 +75,12 @@ scripts/loop-query.sh
 ___
 
 
-The sentences application is now deployed without any restrictions between 
+The sentences application is now deployed without any restrictions between
 components.
 
 To demonstrate that there are no restrictions between services, we access the
 `name` service from the `age` service - an access that is **not necessary** for the
-functioning of the sentences application. 
+functioning of the sentences application.
 
 Export `age` services POD name to an environment variable.
 
@@ -88,7 +88,7 @@ Export `age` services POD name to an environment variable.
 export AGE_POD=$(kubectl get pod -l app=sentences -l mode=age -o jsonpath="{.items[0].metadata.name}")
 ```
 
-First we access the primary endpoint of the `name` service. Run the following 
+First we access the primary endpoint of the `name` service. Run the following
 command.
 
 ```console
@@ -124,15 +124,15 @@ kubectl delete -f 06-service-access-control/start/
 ___
 
 
-To restrict inter-service access to only what is necessary create a file 
-called `name-network-policy.yaml` in the directory 
+To restrict inter-service access to only what is necessary create a file
+called `name-network-policy.yaml` in the directory
 `06-service-access-control/start/`.
 
 Paste in the following yaml.
 
 !INCLUDECODE "06-service-access-control/examples/networkpolicy.yaml" (yaml)
 
-> Note: Not all Kubernetes Network types implements NetworkPolicy. 
+> Note: Not all Kubernetes Network types implements NetworkPolicy.
 > E.g. the *Flannel* network does not, whereas *Calico* and *WeaveNet* does.
 
 This policy applies to the `name` service PODs due to the labels given in
@@ -143,8 +143,8 @@ labels and port given in `spec.ingress`.
 
 ___
 
-Now that you have a network policy redeploy the sentences application services 
-along with the policy by substituting the placeholders with environment variable(s) 
+Now that you have a network policy redeploy the sentences application services
+along with the policy by substituting the placeholders with environment variable(s)
 and applying with kubectl.
 
 ```console
@@ -208,7 +208,7 @@ ___
 
 
 The `sentences` service still has access to the `name` service, which we can
-test by executing a curl command from the container in the `sentences` 
+test by executing a curl command from the container in the `sentences`
 service as you have done for the age container.
 
 Export `sentences` services POD name to an environment variable.
@@ -217,7 +217,7 @@ Export `sentences` services POD name to an environment variable.
 export SENTENCES_POD=$(kubectl get pod -l app=sentences -l mode=sentence -o jsonpath="{.items[0].metadata.name}")
 ```
 
-Access the primary endpoint of the `name` service. by running the following 
+Access the primary endpoint of the `name` service. by running the following
 command.
 
 ```console
@@ -229,7 +229,7 @@ port 5000 will work. The NetworkPolicy **did not allow access to port 8000**.
 So access the to the `name:8000/metrics` endpoint is no longer allowed.
 
 The `sentences` service can still access the `name:5000/choices` URL even though
-this is not needed by the `sentences` service. 
+this is not needed by the `sentences` service.
 
 Execute the following command.
 
@@ -237,8 +237,8 @@ Execute the following command.
 kubectl exec $SENTENCES_POD -c sentences -- curl --silent name:5000/choices; echo "";
 ```
 
-With a Kubernetes NetworkPolicy we cannot specify policies on URLs since these 
-policies are operating at L3/L4 (IP addresses, L4 protocols and ports). For this 
+With a Kubernetes NetworkPolicy we cannot specify policies on URLs since these
+policies are operating at L3/L4 (IP addresses, L4 protocols and ports). For this
 we need an Istio
 [AuthorizationPolicy](https://istio.io/latest/docs/reference/config/security/authorization-policy/)
 which understands L7 (HTTP).
@@ -252,23 +252,23 @@ A feature of Istio is strong workload identities. Istio implements the
 [SPIFFE](https://spiffe.io) standard and provides cryptographic verifiable
 identities to workloads within the mesh.
 
-> These identities are the foundation for authorization and mTLS between 
+> These identities are the foundation for authorization and mTLS between
 > services.
 
-Istio bootstraps trust through Kubernetes service accounts since these can 
-be validated through the Kubernetes certificate authority. **This also means 
-that there is a 1:1 link between Kubernetes service accounts and workload 
-identities in Istio.** 
+Istio bootstraps trust through Kubernetes service accounts since these can
+be validated through the Kubernetes certificate authority. **This also means
+that there is a 1:1 link between Kubernetes service accounts and workload
+identities in Istio.**
 
-PODs in Kubernetes sharing a service account share a workload identity. 
-It is therefore **essential**, that services to which we want to apply 
-different policies are assigned different service accounts. For this 
-purpose, the sentences application we deployed created **three** 
+PODs in Kubernetes sharing a service account share a workload identity.
+It is therefore **essential**, that services to which we want to apply
+different policies are assigned different service accounts. For this
+purpose, the sentences application we deployed created **three**
 different service accounts, one for each of the `sentences`, `age` and
 `name` service.
 
-With different identities assigned to the three services, 
-we can create an `ALLOW` Istio 
+With different identities assigned to the three services,
+we can create an `ALLOW` Istio
 [AuthorizationPolicy](https://istio.io/latest/docs/reference/config/security/authorization-policy/)
 that applies to the `name` service (due to the label selector in
 `spec.selector.matchLabels`).
@@ -276,7 +276,7 @@ that applies to the `name` service (due to the label selector in
 !INCLUDECODE "06-service-access-control/examples/authz-policy.yaml" (yaml)
 
 Note how the policy allows traffic from a workload identified as
-`cluster.local/ns/$STUDENT_NS/sa/sentences`. This identifier should be 
+`cluster.local/ns/$STUDENT_NS/sa/sentences`. This identifier should be
 interpreted like:
 
 ```
@@ -308,10 +308,10 @@ kubectl get po -l mode=sentence -o jsonpath='{.items[*].spec.serviceAccount}'
 
 To allow for running this exercise in different environments, the namespace name
 has been made configurable. To inspect the resulting AuthorizationPolicy use the
-following commands and change the value of `STUDENT_NS` to `<YOUR_NAMESPACE>`, e.g 
+following commands and change the value of `STUDENT_NS` to `<YOUR_NAMESPACE>`, e.g
 student1, student2, etc.
 
-Examine the substitution of the placeholder with the environment variable. 
+Examine the substitution of the placeholder with the environment variable.
 
 ```console
 cat 06-service-access-control/examples/authz-policy.yaml | envsubst
@@ -326,9 +326,9 @@ cat 06-service-access-control/examples/authz-policy.yaml | envsubst | kubectl ap
 If we retry the curl commands from previously from both the `age` and
 `sentences` service, we will see:
 
-- That the only access that is now possible is the `sentences` service accessing the 
+- That the only access that is now possible is the `sentences` service accessing the
 primary `name` endpoint.
-- The `name:5000/choices` endpoint cannot be accessed either. This correlates with the 
+- The `name:5000/choices` endpoint cannot be accessed either. This correlates with the
 AuthorizationPolicy only allowing `GET` towards `/`.
 
 > :bulb: Note that it might take a few seconds for the policy to properly register.
@@ -347,8 +347,8 @@ The main takeaways from this exercise are.
 
 - Istio AuthorizationPolicy's understand L7 networking layer
 
-- Istio bootstraps trust through Kubernetes service accounts. This  means 
-that there is a 1:1 link between Kubernetes service accounts and workload 
+- Istio bootstraps trust through Kubernetes service accounts. This  means
+that there is a 1:1 link between Kubernetes service accounts and workload
 identities in Istio.
 
 Istio AuthorizationPolicy also allows assigning conditions to policies. This

--- a/markdown-source/07-istio-metrics-tour.mdpp
+++ b/markdown-source/07-istio-metrics-tour.mdpp
@@ -185,6 +185,7 @@ If we run `kubectl get pods` now, we will see that we have two containers per
 POD.
 
 > :bulb: It may take a few seconds for the old PODs to terminate.
+> Wait for this before you continue.
 
 Next, observe the values of the Prometheus annotations:
 
@@ -204,7 +205,7 @@ Annotations:  prometheus.io/path: /metrics
 So there is no change in how Prometheus will scrape POD metrics. It
 will still use port `8000` which is handled by the sentences
 application container. Also, if we re-run the curl command from
-previously, we will still only see the `sentence_requests_total`
+previously (with the new pod IP,) we will still only see the `sentence_requests_total`
 metric.
 
 #### Task: Merge Istio and application metrics to one scrape point
@@ -227,6 +228,7 @@ cat 07-istio-metrics-tour/start/age.yaml |egrep -v 'inject|merge-metrics' | kube
 ```
 
 > :bulb: It may take a few seconds for the old PODs to terminate.
+> Wait for this before you continue.
 
 If we now inspect the POD annotations as above, we see the metrics scrape
 endpoint has moved from the application to the sidecar.

--- a/markdown-source/07-istio-metrics-tour.mdpp
+++ b/markdown-source/07-istio-metrics-tour.mdpp
@@ -14,40 +14,40 @@ This exercise will demonstrate how to use metrics from Istio together with
 Prometheus. We will also see how application metrics and Istio metrics work
 together.
 
-> This exercise assumes an Istio deployment with `enablePrometheusMerge` 
+> This exercise assumes an Istio deployment with `enablePrometheusMerge`
 > enabled.
 
-Istio provides telemetry for all service communication within the mesh. 
-This telemetry provides **observability** of service behavior such as 
-overall traffic volume, error rates in traffic and response times. 
-All without any additional effort needed by the developer of a service. 
+Istio provides telemetry for all service communication within the mesh.
+This telemetry provides **observability** of service behavior such as
+overall traffic volume, error rates in traffic and response times.
+All without any additional effort needed by the developer of a service.
 
-One of the types of telemetry Istio generates is metrics. This is done 
-for **all** service traffic in the mesh. Both inbound and outbound. 
+One of the types of telemetry Istio generates is metrics. This is done
+for **all** service traffic in the mesh. Both inbound and outbound.
 
-Istio provides three levels of metrics. 
+Istio provides three levels of metrics.
 
-- Proxy-level: Standard metrics about all pass-through traffic along with 
+- Proxy-level: Standard metrics about all pass-through traffic along with
 detailed statistics about the administrative functions of the proxy itself.
 
-- Service-level: Service oriented metrics for monitoring the service 
+- Service-level: Service oriented metrics for monitoring the service
 communication.
 
 - Control-plane: A collection of self monitoring metrics.
 
-See the [documentation](https://istio.io/latest/docs/concepts/observability/#metrics) 
+See the [documentation](https://istio.io/latest/docs/concepts/observability/#metrics)
 for more details.
 
-> :bulb: If you have not completed exercise 
-> [00-setup-introduction](00-setup-introduction.md) you **need** to label 
+> :bulb: If you have not completed exercise
+> [00-setup-introduction](00-setup-introduction.md) you **need** to label
 > your namespace with `istio-injection=enabled`.
 
 ## Exercise
 
-First you will deploy the sentences service without sidecars and inspect 
-the metrics provided by application. Afterwards you will inject sidecars 
-and inspect the Istio metrics. Then you will enable a single scrape endpoint 
-for both the Istio and application metrics. Finally you view and query Istio 
+First you will deploy the sentences service without sidecars and inspect
+the metrics provided by application. Afterwards you will inject sidecars
+and inspect the Istio metrics. Then you will enable a single scrape endpoint
+for both the Istio and application metrics. Finally you view and query Istio
 metrics in Prometheus.
 
 ### Overview
@@ -144,7 +144,7 @@ This will return something like the following.
 sentence_requests_total{type="name"} 584.0
 ```
 
-This shows that the POD had received `584` requests from the 
+This shows that the POD had received `584` requests from the
 `loop-query.sh` script when we fetched metrics.
 
 Keep the terminal inside the test tool - we will use it again later.
@@ -154,10 +154,10 @@ Keep the terminal inside the test tool - we will use it again later.
 ___
 
 
-The deployed version of the sentences application have Istio sidecar injection 
+The deployed version of the sentences application have Istio sidecar injection
 **disabled**. This is done through annotations.
 
-You can investigate the yaml file `07-istio-metrics-tour/start/sentences.yaml` 
+You can investigate the yaml file `07-istio-metrics-tour/start/sentences.yaml`
 and observe the use of the `sidecar.istio.io/inject` annotation:
 
 ```yaml
@@ -172,7 +172,7 @@ Also note the Prometheus annotations that informs Prometheus, that this POD can
 be scraped for metrics on port `8000` and path `/metrics` - similar to what we
 just did manually.
 
-Re-deploy the sentences application without the annotation that disables 
+Re-deploy the sentences application without the annotation that disables
 sidecar injection.
 
 ```console
@@ -182,7 +182,7 @@ cat 07-istio-metrics-tour/start/age.yaml |grep -v inject | kubectl apply -f -
 ```
 
 If we run `kubectl get pods` now, we will see that we have two containers per
-POD. 
+POD.
 
 > :bulb: It may take a few seconds for the old PODs to terminate.
 
@@ -228,7 +228,7 @@ cat 07-istio-metrics-tour/start/age.yaml |egrep -v 'inject|merge-metrics' | kube
 
 > :bulb: It may take a few seconds for the old PODs to terminate.
 
-If we now inspect the POD annotations as above, we see the metrics scrape 
+If we now inspect the POD annotations as above, we see the metrics scrape
 endpoint has moved from the application to the sidecar.
 
 ```
@@ -242,8 +242,8 @@ Annotations:  prometheus.io/path: /stats/prometheus
 ___
 
 
-Now that we have a single merged scrape endpoint for the application metrics 
-and the Istio metrics we can fetch them both. 
+Now that we have a single merged scrape endpoint for the application metrics
+and the Istio metrics we can fetch them both.
 
 Re-run the `curl` command inside the test-tool as we did previously,
 but this time use the update scrape endpoint information:
@@ -252,8 +252,8 @@ but this time use the update scrape endpoint information:
 curl -s <POD IP>:15020/stats/prometheus | grep requests_total
 ```
 
-The result of which should look somewhat like the following for e.g. 
-the `name` service. 
+The result of which should look somewhat like the following for e.g.
+the `name` service.
 
 ```
 istio_requests_total{response_code="200",
@@ -267,9 +267,9 @@ sentence_requests_total{type="name"}                  265
 > Note the output above is edited for clarity.
 
 Note, that we both see a `sentence_requests_total` metric and an
-`istio_requests_total` metric - the former generated by the sentences 
-application and the other by the Istio sidecar. They should show the same 
-numeric value, however, since the Istio metric contains additional labels, 
+`istio_requests_total` metric - the former generated by the sentences
+application and the other by the Istio sidecar. They should show the same
+numeric value, however, since the Istio metric contains additional labels,
 e.g. source and destination of requests there could be differences
 with the request count spread out on differently labelled `istio_requests_total`
 metrics.
@@ -284,70 +284,70 @@ metrics.
 ___
 
 
-Istio makes the base monitoring data available but you still need something 
-to analyze and put the data to use. 
-[Prometheus](https://istio.io/latest/docs/ops/integrations/prometheus/) is 
-an open source monitoring system and time series database. You can use 
-Prometheus with Istio to record metrics that track the health of Istio and 
-of applications within the service mesh. 
+Istio makes the base monitoring data available but you still need something
+to analyze and put the data to use.
+[Prometheus](https://istio.io/latest/docs/ops/integrations/prometheus/) is
+an open source monitoring system and time series database. You can use
+Prometheus with Istio to record metrics that track the health of Istio and
+of applications within the service mesh.
 
 Browse to prometheus. The instructor should have given you the URL.
 
-Select the **graph** menu item on the top and enter `istio_requests_total` in 
-**Expression** box and hit execute. 
+Select the **graph** menu item on the top and enter `istio_requests_total` in
+**Expression** box and hit execute.
 
 You should see Istio metrics being returned as shown in the below image.
 
 ![Prometheus Istio Requests Total](images/prometheus-istio-requests-total.png)
 
-You can select the **graph** tab to see a graphical representation as shown 
+You can select the **graph** tab to see a graphical representation as shown
 below.
 
 ![Prometheus Istio Requests Total Graph](images/prometheus-istio-total-graph.png)
 
-The above results are for **all** traffic in the mesh, e.g. including traffic 
-going through the ingress gateway. 
+The above results are for **all** traffic in the mesh, e.g. including traffic
+going through the ingress gateway.
 
-If you want narrow the results down to the traffic between the sentences 
-services you could replace the expression with 
-`istio_requests_total{app="sentences"}`. This would give results for **all** 
+If you want narrow the results down to the traffic between the sentences
+services you could replace the expression with
+`istio_requests_total{app="sentences"}`. This would give results for **all**
 the services labelled with `app=sentences` across all namespaces.
 
-If you wanted the results for a specific service, say the `age` service, in a 
-specific namespace you could change the expression to use `destination_service` 
-and specify the full name with `<NAMESPACE>.svc.cluster.local`. 
+If you wanted the results for a specific service, say the `age` service, in a
+specific namespace you could change the expression to use `destination_service`
+and specify the full name with `<NAMESPACE>.svc.cluster.local`.
 
-For example to get istio requests total for the `age` service in the `student1` 
-namespace you could specify the expression 
+For example to get istio requests total for the `age` service in the `student1`
+namespace you could specify the expression
 `istio_requests_total{destination_service="age.student1.svc.cluster.local"}`
 
-Although not part of our course setup you can also visualize metrics using 
-[Grafana](https://istio.io/latest/docs/ops/integrations/grafana/) to create 
+Although not part of our course setup you can also visualize metrics using
+[Grafana](https://istio.io/latest/docs/ops/integrations/grafana/) to create
 Dashboards.
 
 </details>
 
 ## Summary
 
-In this exercise you have inspected some of the metrics Istio provides along 
+In this exercise you have inspected some of the metrics Istio provides along
 with how to enable for Prometheus.
 
 Important takeaways are:
 
-- Istio metrics begin with the sidecar. **Each** proxy generates metrics for 
+- Istio metrics begin with the sidecar. **Each** proxy generates metrics for
 **all** traffic passing through the sidecar proxy. Both inbound and outbound.
 
-- By **default** Istio enables only a small subset of envoy generated 
+- By **default** Istio enables only a small subset of envoy generated
 statistics to avoid overwhelming the metrics backend.
 
-- Istio provides three sets of metrics. Proxy-level metrics, service-level 
+- Istio provides three sets of metrics. Proxy-level metrics, service-level
 metrics and control plane metrics.
 
-- Istio has the ability to control scraping **entirely** by prometheus 
-annotations and this method is enabled by default. When enabled, appropriate 
-prometheus annotations will be added to all data plane pods. 
+- Istio has the ability to control scraping **entirely** by prometheus
+annotations and this method is enabled by default. When enabled, appropriate
+prometheus annotations will be added to all data plane pods.
 
-For an overview of the standard Istio **service-level** metrics see this 
+For an overview of the standard Istio **service-level** metrics see this
 [documentation](https://istio.io/latest/docs/reference/config/metrics/).
 
 ## Cleanup

--- a/markdown-source/08-distributed-tracing.mdpp
+++ b/markdown-source/08-distributed-tracing.mdpp
@@ -11,56 +11,56 @@
 
 ## Introduction
 
-This exercise will introduce some network delays and *slightly* more 
-complex deployment of the sentences application to **introduce** you to 
-another type of telemetry Istio generates. 
-[Distributed trace](https://istio.io/latest/docs/concepts/observability/#distributed-traces) 
-**spans**. 
+This exercise will introduce some network delays and *slightly* more
+complex deployment of the sentences application to **introduce** you to
+another type of telemetry Istio generates.
+[Distributed trace](https://istio.io/latest/docs/concepts/observability/#distributed-traces)
+**spans**.
 
-It will also introduce you to **one** of the distributed tracing backends 
+It will also introduce you to **one** of the distributed tracing backends
 Istio integrates with. [Jaeger](https://istio.io/latest/docs/ops/integrations/jaeger/).
 
-Istio supports distributed tracing through the envoy proxy sidecar. The proxies 
-**automatically** generate trace **spans** on **behalf** applications they proxy. 
-The sidecar proxy will send the tracing information directly to the tracing 
-backends. So the application developer does **not** know or worry about a 
-distributed tracing backend. 
+Istio supports distributed tracing through the envoy proxy sidecar. The proxies
+**automatically** generate trace **spans** on **behalf** applications they proxy.
+The sidecar proxy will send the tracing information directly to the tracing
+backends. So the application developer does **not** know or worry about a
+distributed tracing backend.
 
-However, Istio **does** rely on the application to propagate some headers for 
-subsequent outgoing requests so it can stitch together a complete view of the 
-traffic. See more **More Istio Distributed Tracing** below for a list of the 
+However, Istio **does** rely on the application to propagate some headers for
+subsequent outgoing requests so it can stitch together a complete view of the
+traffic. See more **More Istio Distributed Tracing** below for a list of the
 **required** headers.
 
 <details>
     <summary> More Istio Distributed Tracing </summary>
 
-Some forms of delays can be observed with the **metrics** that Istio tracks. 
+Some forms of delays can be observed with the **metrics** that Istio tracks.
 
-> Metrics are statistical and not specific to a certain request, i.e. we can 
-> only observe statistical data about observations like sums and averages. 
+> Metrics are statistical and not specific to a certain request, i.e. we can
+> only observe statistical data about observations like sums and averages.
 
-This is quite useful but fairly limited in a more complex service based 
-architecture. If the delay was caused by something more complicated it 
-could be difficult to diagnose purely from metrics due to their 
-statistical nature. For example the misbehaving application might not be 
-the immediate one from which you are observing a delay. In fact, it might 
+This is quite useful but fairly limited in a more complex service based
+architecture. If the delay was caused by something more complicated it
+could be difficult to diagnose purely from metrics due to their
+statistical nature. For example the misbehaving application might not be
+the immediate one from which you are observing a delay. In fact, it might
 be deep in the application tree.
 
-Distributed traces with spans provide a view of the life of a request as it 
+Distributed traces with spans provide a view of the life of a request as it
 travels across multiple hosts and service.
 
-> The “span” is the primary building block of a distributed trace, representing 
-> an individual unit of work done in a distributed system. Each component of the 
-> distributed system contributes a span - a named, timed operation representing 
+> The “span” is the primary building block of a distributed trace, representing
+> an individual unit of work done in a distributed system. Each component of the
+> distributed system contributes a span - a named, timed operation representing
 > a piece of the workflow.
-> 
-> Spans can (and generally do) contain “References” to other spans, which allows 
-> multiple Spans to be assembled into one complete Trace - a visualization of the 
+>
+> Spans can (and generally do) contain “References” to other spans, which allows
+> multiple Spans to be assembled into one complete Trace - a visualization of the
 > life of a request as it moves through a distributed system.
 
-In order for Istio to stitch together the spans and provide this view of the life 
-of a request. Istio Requires the following 
-[B3 trace headers](https://github.com/openzipkin/b3-propagation) to be propagated 
+In order for Istio to stitch together the spans and provide this view of the life
+of a request. Istio Requires the following
+[B3 trace headers](https://github.com/openzipkin/b3-propagation) to be propagated
 across the services.
 
 - x-request-id
@@ -73,18 +73,18 @@ across the services.
 
 </details>
 
-> :bulb: If you have not completed exercise 
-> [00-setup-introduction](00-setup-introduction.md) you **need** to label 
+> :bulb: If you have not completed exercise
+> [00-setup-introduction](00-setup-introduction.md) you **need** to label
 > your namespace with `istio-injection=enabled`.
 
 ## Exercise
 
-You are going to deploy a *slightly* more complex version of the sentences 
-application with a (simulated) bug that causes large delays on the combined 
-service. 
+You are going to deploy a *slightly* more complex version of the sentences
+application with a (simulated) bug that causes large delays on the combined
+service.
 
-Then you are going to see how Istio's distributed tracing telemetry is 
-leveraged by Kiali and Jaeger to help you identify where the delay is 
+Then you are going to see how Istio's distributed tracing telemetry is
+leveraged by Kiali and Jaeger to help you identify where the delay is
 happening.
 
 ### Overview
@@ -99,7 +99,7 @@ A general overview of what you will be doing in the **Step By Step** section.
 
 - Observe the distributed tracing telemetry in Jaeger
 
-- Route traffic through the ingress gateway 
+- Route traffic through the ingress gateway
 
 - Observe the distributed tracing telemetry in Jaeger
 
@@ -124,7 +124,7 @@ kubectl apply -f 08-distributed-tracing/start/
 ___
 
 
-In another shell, run the following to continuously query the sentence 
+In another shell, run the following to continuously query the sentence
 service through the **NodePort**.
 
 ```console
@@ -136,8 +136,8 @@ scripts/loop-query.sh
 ___
 
 
-Go to Graph menu item and select the **Versioned app graph** from the drop 
-down menu. 
+Go to Graph menu item and select the **Versioned app graph** from the drop
+down menu.
 
 If we select to display 'response time' we can see that traffic is flowing with relatively low delay on responses
 
@@ -158,8 +158,8 @@ kubectl apply -f 08-distributed-tracing/start/sentences-v2/
 ___
 
 
-Go to Graph menu item and select the **Versioned app graph** from the drop 
-down menu. 
+Go to Graph menu item and select the **Versioned app graph** from the drop
+down menu.
 
 If we select to display 'response time' we can see that there is a
 significant delay introduced by `v2` of the sentences
@@ -174,18 +174,18 @@ affecting both `v1` and `v2`:
 ___
 
 
-This is just a simulated bug and is easy to locate. But in a real world 
-scenario the bug may be introduced by interaction of a service deeper in the 
-application tree. To do a proper investigation you may need to trace the 
+This is just a simulated bug and is easy to locate. But in a real world
+scenario the bug may be introduced by interaction of a service deeper in the
+application tree. To do a proper investigation you may need to trace the
 traffic flow of the request through this tree.
 
-Kiali leverages Istio's distributed tracing telemetry and can be used to help 
+Kiali leverages Istio's distributed tracing telemetry and can be used to help
 in this type of scenario.
 
 Browse to **Workloads** on the left hand menu and select the `sentences-v2`
 workload. Then select the **Traces** tab.
 
-Here you can see that there are outlier **spans** well over 1 second. These 
+Here you can see that there are outlier **spans** well over 1 second. These
 are the spans generated by Istio.
 
 ![Kiali Traces](images/kiali-sentences-delay-traces.png)
@@ -194,17 +194,17 @@ Select one of the spans and Kiali will give you some trace details.
 
 ![Kiali Trace Details](images/kiali-trace-details.png)
 
-Select the **Span Details** tab and you can see the different spans generated 
-by the envoy proxy. Expanding the different entries will let you see details 
+Select the **Span Details** tab and you can see the different spans generated
+by the envoy proxy. Expanding the different entries will let you see details
 about where the request was sent and the response status.
 
 ![Kiali Span Details](images/kiali-span-details.png)
 
-> The colors on the span and trace details is controlled by Kiali so it 
-> is easier to see problems. The colors are based on an average of 
-> comparisons of each span duration vs the metrics for the same 
-> source/destination services. See this 
-> [blog](https://medium.com/kialiproject/trace-my-mesh-part-2-3-13cd6ccae1de) 
+> The colors on the span and trace details is controlled by Kiali so it
+> is easier to see problems. The colors are based on an average of
+> comparisons of each span duration vs the metrics for the same
+> source/destination services. See this
+> [blog](https://medium.com/kialiproject/trace-my-mesh-part-2-3-13cd6ccae1de)
 > for a more detailed dive into how Kiali does this.
 
 #### Task: Observe the distributed tracing telemetry in Jaeger
@@ -212,15 +212,15 @@ about where the request was sent and the response status.
 ___
 
 
-Jaeger also leverages Istio's distributed tracing and can also be used to 
-identify scenarios like this. 
+Jaeger also leverages Istio's distributed tracing and can also be used to
+identify scenarios like this.
 
-> It can be argued that Jaeger gives an easier to understand and more logical 
+> It can be argued that Jaeger gives an easier to understand and more logical
 > view of the traffic flow of a request.
 
 Browse to Jaeger and select the options as shown below and hit find traces.
 
-> :bulb: Select the sentences service corresponding to **your** namespace. 
+> :bulb: Select the sentences service corresponding to **your** namespace.
 > E.g `sentences.student1`, `sentences.student2`, etc.
 
 You should see a trace taking longer than 1 second in the graph and
@@ -230,7 +230,7 @@ the most resent traces).
 
 ![Search Traces In Jaeger](images/jaeger-delay-search.png)
 
-Select the trace, either from the graph or the list of traces. Then select 
+Select the trace, either from the graph or the list of traces. Then select
 the first entry in the flow and **expand** the **Tags** section.
 
 ![Jaeger Trace Details](images/jaeger-delay-details-initial.png)
@@ -242,8 +242,8 @@ bee seen as the root cause of the long delay.
 
 Next, select the first entry in the flow and **expand** the **Tags** section.
 
-From the details you can see that the envoy proxy provided the trace. You can 
-also see that the version of the sentences service is `v2`. 
+From the details you can see that the envoy proxy provided the trace. You can
+also see that the version of the sentences service is `v2`.
 
 ![Jaeger Trace Details](images/jaeger-delay-details.png)
 
@@ -252,15 +252,15 @@ also see that the version of the sentences service is `v2`.
 ___
 
 
-The traffic flow in our sentences application is pretty simple with low 
-complexity. But in much more complex system with a much more complicated 
-traffic flow and many more service the ability of the envoy proxy to provide 
+The traffic flow in our sentences application is pretty simple with low
+complexity. But in much more complex system with a much more complicated
+traffic flow and many more service the ability of the envoy proxy to provide
 traces without changes required at the application level is quite powerful.
 
-As an example you will create an ingress gateway and virtual service to route 
+As an example you will create an ingress gateway and virtual service to route
 external traffic through it to the sentences service.
 
-First create a file called `sentences-ingress-gw.yaml` in the directory 
+First create a file called `sentences-ingress-gw.yaml` in the directory
 `08-distributed-tracing/start/`.
 
 > :bulb: Edit the hosts field with **your** namespace.
@@ -283,7 +283,7 @@ spec:
     - "$STUDENT_NS.sentences.$TRAINING_NAME.eficode.academy"
 ```
 
-Then create a file `sentences-ingress-vs.yaml` in the directory 
+Then create a file `sentences-ingress-vs.yaml` in the directory
 `08-distributed-tracing/start/`.
 
 ```yaml
@@ -314,15 +314,15 @@ envsubst < 08-distributed-tracing/start/sentences-ingress-vs.yaml | kubectl appl
 ___
 
 
-Now instead of hitting the NodePort of the sentences service use the 
-`./scripts/loop-query.sh` with the `-g` option and the entry point of 
+Now instead of hitting the NodePort of the sentences service use the
+`./scripts/loop-query.sh` with the `-g` option and the entry point of
 the gateway you just created.
 
 ```console
 ./scripts/loop-query.sh -g $STUDENT_NS.sentences.$TRAINING_NAME.eficode.academy
 ```
 
-Traffic will now be routed through the ingress gateway and towards the 
+Traffic will now be routed through the ingress gateway and towards the
 sentences service.
 
 #### Task: Observe the distributed tracing telemetry in Jaeger
@@ -336,7 +336,7 @@ You should be able to see the request flowing through the ingress gateway now.
 
 ![Jaeger Ingress Search](images/jaeger-ingress-search.png)
 
-If you select one of the traces, either from the graph or the list of traces, 
+If you select one of the traces, either from the graph or the list of traces,
 you should be able to see the ingress gateway as part of the traffic flow details.
 
 ![Jaeger Ingress Details](images/jaeger-ingress-details.png)
@@ -345,21 +345,21 @@ you should be able to see the ingress gateway as part of the traffic flow detail
 
 ## Summary
 
-In this exercise you have seen how Istio's distributed tracing telemetry 
-can be leveraged to provide a less intrusive and more cohesive approach 
+In this exercise you have seen how Istio's distributed tracing telemetry
+can be leveraged to provide a less intrusive and more cohesive approach
 to distributed tracing.
 
 The main takeaways are:
 
 - Istio's envoy proxies generate the distributed trace spans for the services.
 
-- If a service has no proxy sidecar, distributed trace telemetry will not 
+- If a service has no proxy sidecar, distributed trace telemetry will not
 be generated.
 
-- Istio's envoy proxies provide the distributed trace telemetry to the 
+- Istio's envoy proxies provide the distributed trace telemetry to the
 supported backends integrated with the mesh.
 
-- The only requirement for the service is to propagate the **required** 
+- The only requirement for the service is to propagate the **required**
 B3 trace headers.
 
 ## Cleanup

--- a/markdown-source/08-distributed-tracing.mdpp
+++ b/markdown-source/08-distributed-tracing.mdpp
@@ -47,7 +47,7 @@ the immediate one from which you are observing a delay. In fact, it might
 be deep in the application tree.
 
 Distributed traces with spans provide a view of the life of a request as it
-travels across multiple hosts and service.
+travels across multiple hosts and services.
 
 > The “span” is the primary building block of a distributed trace, representing
 > an individual unit of work done in a distributed system. Each component of the
@@ -254,16 +254,16 @@ ___
 
 The traffic flow in our sentences application is pretty simple with low
 complexity. But in much more complex system with a much more complicated
-traffic flow and many more service the ability of the envoy proxy to provide
+traffic flow and many more services, the ability of the envoy proxy to provide
 traces without changes required at the application level is quite powerful.
 
-As an example you will create an ingress gateway and virtual service to route
+As an example you will create an IngressGateway and VirtualService to route
 external traffic through it to the sentences service.
 
 First create a file called `sentences-ingress-gw.yaml` in the directory
 `08-distributed-tracing/start/`.
 
-> :bulb: Edit the hosts field with **your** namespace.
+> :bulb: Edit the hosts field with **your** namespace. (With `envsubst` in the commands below.)
 
 ```yaml
 apiVersion: networking.istio.io/v1beta1
@@ -333,6 +333,20 @@ ___
 Browse to Jaeger and select the options as shown below and hit find traces.
 
 You should be able to see the request flowing through the ingress gateway now.
+
+> NB: it might take a minute or two for the traces to show up,
+> so don't get worried if you can't see them right away!
+>
+> :bulb: For demonstrating purposes, the Jaeger and Istio deployed during
+> a training has been configured to collect **all** traces;
+> their default settings is to only keep between 0.1-1% of the traces.
+>
+> For performance: In a production-system with thousands or even millions of requests each second,
+> collecting everything would be infeasible, but the `loop-query`-script,
+> only sends a couple of requests each second.
+>
+> For practicalities: Storing everything means we won't have to "get lucky" (in terms of this exercise)
+> when the system chooses which traces to keep or discard.
 
 ![Jaeger Ingress Search](images/jaeger-ingress-search.png)
 


### PR DESCRIPTION
- strip all trailing whitespace from `*.md`-files
- strip all trailing whitespace from `*.mdpp`-files
- update `*.mdpp`-files to match what's been inline edited in the `*.md`-files

Updates to markdown should be done in the `*.mdpp`-files and generated w/ `make all` using Docker.

--- 

Verifying the PR.

1. Pull the branch down locally, and run:

```
gd --word-diff -w main *.md
```

To see that the only thing that's changed in the markdown files is "a single newline" (when you only show changed words and omit whitespace.

2. Use `rm -f 0*.md` to delete all the 0-exercise markdown.
  - Use `git status` and notice that all the files are deleted.
  - Use `make all` (with Docker) to regenerate all the files.
  - Notice how "nothing has changed" in git. Because the `*.mdpp`-files perfectly match the output.